### PR TITLE
Add initial HVAC view

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -4,6 +4,7 @@ import React from 'react';
 import {TabbedPanels} from '@enact/agate/Panels';
 
 import Home from '../views/Home';
+import HVAC from '../views/HVAC';
 import Phone from '../views/Phone';
 import MainPanel from '../views/MainPanel';
 
@@ -25,6 +26,7 @@ const AppBase = kind({
 			tabs={[
 				{title: 'Home', view: Home},
 				{title: 'Phone', view: Phone},
+				{title: 'HVAC', view: HVAC},
 				{title: 'Hello!', view: MainPanel}
 			]}
 		/>

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -37,7 +37,7 @@ const AppBase = kind({
 							onToggleBasicPopup
 						}},
 						{title: 'Phone', icon: 'funnel', view: Phone},
-						{title: 'HVAC', view: HVAC},
+						{title: 'HVAC', icon: 'play', view: HVAC},
 						{title: 'Hello!', icon: 'search', view: MainPanel}
 					]}
 				>

--- a/console/src/views/HVAC.js
+++ b/console/src/views/HVAC.js
@@ -7,47 +7,32 @@ import kind                  from '@enact/core/kind';
 import {Row, Cell}           from '@enact/ui/Layout';
 import React                 from 'react';
 
-// import HeatedSeatButton      from '../components/HeatedSeatButton';
-// import Temp                  from '../components/Temp';
-
 import css                   from './HVAC.less';
 
 const Hvac = kind({
-    name: 'HVAC',
-
-	propTypes: {
-		// Define and document properties
-	},
-
-	// Define default values for any properties that have them
-	// defaultProps: {
-	// },
+	name: 'HVAC',
 
 	styles: {
 		css,
 		className: 'hvac'
 	},
 
-	// Add computed property values
-	// computed: {
-	// },
-
 	render: (props) => (
 		<Panel {...props}>
-            <Divider>
-                Fan Speed
-            </Divider>
+			<Divider>
+				Fan Speed
+			</Divider>
 			<SliderButton>
-                {'Off'}
-                {'Low'}
-                {'Medium'}
-                {'High'}
-            </SliderButton>
+				{'Off'}
+				{'Low'}
+				{'Medium'}
+				{'High'}
+			</SliderButton>
 			<Row className={css.above + ' ' + css.spaced}>
 				<LabeledIconButton icon="plus">L Seat</LabeledIconButton>
-                <Button type="grid" className={css.button}>
-                    A/C
-                </Button>
+				<Button type="grid" className={css.button}>
+					A/C
+				</Button>
 				<LabeledIconButton icon="plus">R Seat</LabeledIconButton>
 			</Row>
 			<Row className={css.below + ' ' + css.spaced}>
@@ -58,18 +43,18 @@ const Hvac = kind({
 					<Button type="grid" className={css.button}>
 						AUTO
 					</Button>
-                    <Button type="grid" icon="rollforward" className={css.button} />
-                </div>
+					<Button type="grid" icon="rollforward" className={css.button} />
+				</div>
 				<Cell>
 					Picker
 				</Cell>
 			</Row>
 			<Row className={css.spaced}>
-				<LabeledIconButton icon="arrowsmalldown">Air Down</LabeledIconButton>
-				<LabeledIconButton icon="arrowsmallup">Air Up</LabeledIconButton>
-				<LabeledIconButton icon="arrowsmallright">Air Face</LabeledIconButton>
-				<LabeledIconButton icon="hollowstar">Rear Defrost</LabeledIconButton>
-				<LabeledIconButton icon="hollowstar">Front Defrost</LabeledIconButton>
+				<LabeledIconButton icon="arrowsmalldown">Down</LabeledIconButton>
+				<LabeledIconButton icon="arrowsmallup">Up</LabeledIconButton>
+				<LabeledIconButton icon="arrowsmallright">Face</LabeledIconButton>
+				<LabeledIconButton icon="hollowstar">Rear</LabeledIconButton>
+				<LabeledIconButton icon="hollowstar">Front</LabeledIconButton>
 			</Row>
 		</Panel>
 	)
@@ -77,6 +62,6 @@ const Hvac = kind({
 
 export default Hvac;
 export {
-    Hvac as App,
-    Hvac
+	Hvac as App,
+	Hvac
 };

--- a/console/src/views/HVAC.js
+++ b/console/src/views/HVAC.js
@@ -29,11 +29,11 @@ const Hvac = kind({
 				{'High'}
 			</SliderButton>
 			<Row className={css.above + ' ' + css.spaced}>
-				<LabeledIconButton icon="plus">L Seat</LabeledIconButton>
+				<Button icon="plus" />
 				<Button type="grid" className={css.button}>
 					A/C
 				</Button>
-				<LabeledIconButton icon="plus">R Seat</LabeledIconButton>
+				<Button icon="plus" />
 			</Row>
 			<Row className={css.below + ' ' + css.spaced}>
 				<Cell>

--- a/console/src/views/HVAC.js
+++ b/console/src/views/HVAC.js
@@ -1,0 +1,82 @@
+import Button                from '@enact/agate/Button';
+import Divider               from '@enact/agate/Divider';
+import LabeledIconButton     from '@enact/agate/LabeledIconButton';
+import {Panel}               from '@enact/agate/Panels';
+import SliderButton          from '@enact/agate/SliderButton';
+import kind                  from '@enact/core/kind';
+import {Row, Cell}           from '@enact/ui/Layout';
+import React                 from 'react';
+
+// import HeatedSeatButton      from '../components/HeatedSeatButton';
+// import Temp                  from '../components/Temp';
+
+import css                   from './HVAC.less';
+
+const Hvac = kind({
+    name: 'HVAC',
+
+	propTypes: {
+		// Define and document properties
+	},
+
+	// Define default values for any properties that have them
+	// defaultProps: {
+	// },
+
+	styles: {
+		css,
+		className: 'hvac'
+	},
+
+	// Add computed property values
+	// computed: {
+	// },
+
+	render: (props) => (
+		<Panel {...props}>
+            <Divider>
+                Fan Speed
+            </Divider>
+			<SliderButton>
+                {'Off'}
+                {'Low'}
+                {'Medium'}
+                {'High'}
+            </SliderButton>
+			<Row className={css.above + ' ' + css.spaced}>
+				<LabeledIconButton icon="plus">L Seat</LabeledIconButton>
+                <Button type="grid" className={css.button}>
+                    A/C
+                </Button>
+				<LabeledIconButton icon="plus">R Seat</LabeledIconButton>
+			</Row>
+			<Row className={css.below + ' ' + css.spaced}>
+				<Cell>
+					Picker
+				</Cell>
+				<div>
+					<Button type="grid" className={css.button}>
+						AUTO
+					</Button>
+                    <Button type="grid" icon="rollforward" className={css.button} />
+                </div>
+				<Cell>
+					Picker
+				</Cell>
+			</Row>
+			<Row className={css.spaced}>
+				<LabeledIconButton icon="arrowsmalldown">Air Down</LabeledIconButton>
+				<LabeledIconButton icon="arrowsmallup">Air Up</LabeledIconButton>
+				<LabeledIconButton icon="arrowsmallright">Air Face</LabeledIconButton>
+				<LabeledIconButton icon="hollowstar">Rear Defrost</LabeledIconButton>
+				<LabeledIconButton icon="hollowstar">Front Defrost</LabeledIconButton>
+			</Row>
+		</Panel>
+	)
+});
+
+export default Hvac;
+export {
+    Hvac as App,
+    Hvac
+};

--- a/console/src/views/HVAC.less
+++ b/console/src/views/HVAC.less
@@ -1,0 +1,21 @@
+.hvac {
+    padding: 24px;
+    
+    .button {
+        min-width: 160px;
+        display: block;
+    }
+
+	.above {
+        padding-top: 64px;
+	}
+
+	.below {
+        padding-bottom: 64px;
+	}
+
+	.spaced {
+		align-content: space-between;
+		justify-content: space-around;
+	}
+}

--- a/console/src/views/HVAC.less
+++ b/console/src/views/HVAC.less
@@ -17,5 +17,6 @@
 	.spaced {
 		align-content: space-between;
 		justify-content: space-around;
+		align-items: center;
 	}
 }


### PR DESCRIPTION
Related Issue: #6 

* Adds basic layout for HVAC Screen
* Uses `SliderButton` rather than adding a slider but we can harvest that as well if desired

Needs:
* Picker component for temp control
* Icons for buttons. Might convert them to `Button` instead of `LabeledIconButton` once the icons are meaningful
* Add custom component for heated seat control. AGL version is tri-mode -- off, low, high
* Some behaviors applied (e.g. selecting Auto might disable the fan slider and fan selector icon buttons)

![image](https://user-images.githubusercontent.com/788456/44934336-549e8100-ad21-11e8-997f-b360dc7dd583.png)

