### PR TITLE
Add navigation support using pushState

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -36,6 +36,7 @@
 		"@enact/spotlight": "^2.1.1",
 		"@enact/ui": "^2.1.1",
 		"prop-types": "^15.6.2",
+		"query-string": "^6.1.0",
 		"react": "^16.4.2",
 		"react-dom": "^16.4.2"
 	}

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -1,5 +1,7 @@
 import AgateDecorator from '@enact/agate/AgateDecorator';
+import {adaptEvent, forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
+import Changeable from '@enact/ui/Changeable';
 import React from 'react';
 import {TabbedPanels} from '@enact/agate/Panels';
 
@@ -17,6 +19,14 @@ const AppBase = kind({
 		className: 'app'
 	},
 
+	handlers: {
+		onSelect: handle(
+			// this should probably be done in TabbedPanels to line up the event payload (index)
+			// with the prop but i'm taking a shortcut for now
+			adaptEvent(({selected}) => ({index: selected}), forward('onSelect'))
+		)
+	},
+
 	render: (props) => (
 		<TabbedPanels
 			{...props}
@@ -31,28 +41,11 @@ const AppBase = kind({
 	)
 });
 
-class App extends React.Component {
-	constructor (props) {
-		super(props);
-		this.state = {
-			index: props.index || 0
-		};
-	}
-	onSelect = (ev) => {
-		const {selected: index} = ev;
-		if (typeof index === 'number' && index !== this.state.index) {
-			this.setState({index});
-		}
-	};
-	render () {
-		const props = Object.assign({}, this.props);
-		props.index = this.state.index;
-		props.onSelect = this.onSelect;
+const App = AgateDecorator(
+	Changeable(
+		{change: 'onSelect', prop: 'index'},
+		AppBase
+	)
+);
 
-		return(
-			<AppBase {...props} />
-		);
-	}
-}
-
-export default AgateDecorator(App);
+export default App;

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -1,23 +1,19 @@
 import AgateDecorator from '@enact/agate/AgateDecorator';
-<<<<<<< HEAD
-import {adaptEvent, forward, handle} from '@enact/core/handle';
-=======
 import Button from '@enact/agate/Button';
-import Popup from '@enact/agate/Popup';
-import compose from 'ramda/src/compose';
-import hoc from '@enact/core/hoc';
->>>>>>> origin/master
-import kind from '@enact/core/kind';
-import Changeable from '@enact/ui/Changeable';
-import React from 'react';
-import Layout, {Cell} from '@enact/ui/Layout';
 import {TabbedPanels} from '@enact/agate/Panels';
+import Popup from '@enact/agate/Popup';
+import {adaptEvent, forward, handle} from '@enact/core/handle';
+import hoc from '@enact/core/hoc';
+import kind from '@enact/core/kind';
+import Layout, {Cell} from '@enact/ui/Layout';
+import compose from 'ramda/src/compose';
+import React from 'react';
 
 import Clock from '../components/Clock';
 import Home from '../views/Home';
 import HVAC from '../views/HVAC';
-import Phone from '../views/Phone';
 import MainPanel from '../views/MainPanel';
+import Phone from '../views/Phone';
 
 import css from './App.less';
 
@@ -93,31 +89,36 @@ const AppState = hoc((configHoc, Wrapped) => {
 		constructor (props) {
 			super(props);
 			this.state = {
-				index: props.defaultIndex || props.index || 0,
+				index: props.defaultIndex || 0,
 				showPopup: false,
 				showBasicPopup: false,
-				skin: props.skin || 'carbon' // 'titanium' alternate.
+				skin: props.defaultSkin || 'carbon' // 'titanium' alternate.
 			};
 		}
-		onSelect = (ev) => {
-			const {selected: index} = ev;
-			if (typeof index === 'number' && index !== this.state.index) {
-				this.setState({index});
-			}
-		};
+
+		onSelect = handle(
+			forward('onSelect'),
+			({index}) => this.setState(state => state.index === index ? null : {index})
+		).bind(this)
+
 		onSkinChange = () => {
 			this.setState(({skin}) => ({skin: (skin === 'carbon' ? 'titanium' : 'carbon')}));
-		};
+		}
+
 		onTogglePopup = () => {
 			this.setState(({showPopup}) => ({showPopup: !showPopup}));
-		};
+		}
+
 		onToggleBasicPopup = () => {
 			this.setState(({showBasicPopup}) => ({showBasicPopup: !showBasicPopup}));
-		};
+		}
+
 		render () {
 			const props = {...this.props};
+
 			delete props.defaultIndex;
-			return(
+
+			return (
 				<Wrapped
 					{...props}
 					index={this.state.index}
@@ -125,11 +126,11 @@ const AppState = hoc((configHoc, Wrapped) => {
 					onSkinChange={this.onSkinChange}
 					onTogglePopup={this.onTogglePopup}
 					onToggleBasicPopup={this.onToggleBasicPopup}
+					orientation={(this.state.skin === 'titanium') ? 'horizontal' : 'vertical'}
 					showPopup={this.state.showPopup}
 					showBasicPopup={this.state.showBasicPopup}
 					skin={this.state.skin}
 					skinName={this.state.skin}
-					orientation={(this.state.skin === 'titanium') ? 'horizontal' : 'vertical'}
 				/>
 			);
 		}

--- a/console/src/components/Clock/Clock.js
+++ b/console/src/components/Clock/Clock.js
@@ -1,4 +1,3 @@
-import Button from '@enact/agate/Button';
 import kind from '@enact/core/kind';
 import hoc from '@enact/core/hoc';
 import {Layout, Cell} from '@enact/ui/Layout';

--- a/console/src/index.js
+++ b/console/src/index.js
@@ -19,8 +19,8 @@ if (typeof window !== 'undefined') {
 	appElement = (
 		<App
 			defaultIndex={index}
+			defaultSkin={skin}
 			onSelect={onSelect}
-			skin={skin}
 		/>
 	);
 

--- a/console/src/index.js
+++ b/console/src/index.js
@@ -1,11 +1,29 @@
+/* eslint-disable react/jsx-no-bind */
+
 import React from 'react';
 import {render} from 'react-dom';
+import qs from 'query-string';
+
 import App from './App';
 
-const appElement = (<App />);
+let appElement = <App />;
 
 // In a browser environment, render instead of exporting
 if (typeof window !== 'undefined') {
+	const args = qs.parse(window.location.search);
+	const index = parseInt(args.index || 0);
+	const skin = args.skin;
+
+	const onSelect = (ev) => window.history.pushState(ev, '', `?index=${ev.index}`)
+
+	appElement = (
+		<App
+			defaultIndex={index}
+			onSelect={onSelect}
+			skin={skin}
+		/>
+	);
+
 	render(appElement, document.getElementById('root'));
 }
 


### PR DESCRIPTION
* Refactors App to use Changeable instead of custom decorator (gives us `defaultIndex` support out of the box + less custom code)
* Adds some boilerplate logic in index.js to `pushState` when `index` changes
* Adapts `onSelect` to pass `index` instead of `selected` up to `Changeable`