### PR TITLE
Sampler: Add ProgressBar

### DIFF
--- a/sampler/stories/default/ProgressBar.js
+++ b/sampler/stories/default/ProgressBar.js
@@ -1,4 +1,5 @@
-import ProgressBar from '@enact/agate/ProgressBar';
+import ProgressBar, {ProgressBarBase} from '@enact/agate/ProgressBar';
+import UiProgressBar from '@enact/ui/ProgressBar';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
@@ -7,7 +8,7 @@ import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
 ProgressBar.displayName = 'ProgressBar';
-const Config = mergeComponentMetadata('ProgressBar', ProgressBar);
+const Config = mergeComponentMetadata('ProgressBar', UiProgressBar, ProgressBarBase, ProgressBar);
 
 storiesOf('Agate', module)
 	.add(
@@ -19,8 +20,8 @@ storiesOf('Agate', module)
 				disabled={boolean('disabled', Config)}
 				focused={boolean('focused', Config)}
 				small={boolean('small', Config)}
-				orientation={select('orientation', ['horizontal', 'vertical'], Config, 'horizontal')}
-				progress={number('progress', 0.5)}
+				orientation={select('orientation', ['horizontal', 'vertical'], Config)}
+				progress={number('progress', Config, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
 			/>
 		))
 	);

--- a/sampler/stories/default/ProgressBar.js
+++ b/sampler/stories/default/ProgressBar.js
@@ -1,0 +1,26 @@
+import ProgressBar from '@enact/agate/ProgressBar';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import {boolean, number, select} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
+ProgressBar.displayName = 'ProgressBar';
+const Config = mergeComponentMetadata('ProgressBar', ProgressBar);
+
+storiesOf('Agate', module)
+	.add(
+		'ProgressBar',
+		withInfo({
+			text: 'The basic ProgressBar'
+		})(() => (
+			<ProgressBar
+				disabled={boolean('disabled', Config)}
+				focused={boolean('focused', Config)}
+				small={boolean('small', Config)}
+				orientation={select('orientation', ['horizontal', 'vertical'], Config, 'horizontal')}
+				progress={number('progress', 0.5)}
+			/>
+		))
+	);


### PR DESCRIPTION
As part of https://github.com/enactjs/agate/pull/70
Add `ProgressBar` sample:

<img width="715" alt="carb" src="https://user-images.githubusercontent.com/8940009/47465530-43fb0c00-d7a2-11e8-9be3-381e45eb1c6e.png">
<img width="718" alt="titan" src="https://user-images.githubusercontent.com/8940009/47465527-43627580-d7a2-11e8-88b1-f8b774295c99.png">
<img width="720" alt="elc" src="https://user-images.githubusercontent.com/8940009/47465529-43fb0c00-d7a2-11e8-8838-542edc70fea3.png">
