### PR TITLE
PLAT-68751: Set destination on routing response

### DIFF
--- a/console/src/data/ServiceLayer.js
+++ b/console/src/data/ServiceLayer.js
@@ -153,8 +153,8 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 		}
 
 		onRoutingResponse = (message) => {
-			const lastWaypoint = message.routing_request.waypoint.slice(-1).pop().pose;
-			const destination = getLatLongFromSim(lastWaypoint.x, lastWaypoint.y);
+			const {x, y} = message.routing_request.waypoint.slice(-1).pop().pose;
+			const destination = getLatLongFromSim(x, y);
 			this.setDestination({destination});
 		}
 

--- a/console/src/data/ServiceLayer.js
+++ b/console/src/data/ServiceLayer.js
@@ -81,7 +81,8 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 						this.props.setConnected(false);
 					},
 					onPosition: this.onPosition,
-					onRoutingRequest: this.onRoutingRequest
+					onRoutingRequest: this.onRoutingRequest,
+					onRoutingResponse: this.onRoutingResponse
 				});
 			}
 		}
@@ -151,6 +152,11 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 			}
 		}
 
+		onRoutingResponse = (message) => {
+			const lastWaypoint = message.routing_request.waypoint.slice(-1).pop().pose;
+			const destination = getLatLongFromSim(lastWaypoint.x, lastWaypoint.y);
+			this.setDestination({destination});
+		}
 
 		//
 		// General Event Handling

--- a/console/src/data/connector.js
+++ b/console/src/data/connector.js
@@ -21,6 +21,11 @@ const subscribedTopics = {
 		name: '/apollo/routing_request',
 		queue_length: 1, // eslint-disable-line camelcase
 		messageType: 'pb_msgs/RoutingRequest'
+	},
+
+	routingResponse: {
+		name: '/apollo/routing_response',
+		messageType: 'pb_msgs/RoutingResponse'
 	}
 
 	// detected: {


### PR DESCRIPTION
`destination` app state needs to be in sync with the router. In case of an abrupt app reload, the destination state will be lost as we don't persist the data. By adding the `responseRoute` topic to ROS we can subscribe and get the last waypoint, which is the destination. This will be set when the component mounts.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>