### PR TITLE
Welcome screen cleanup

### DIFF
--- a/console/src/components/DestinationList/DestinationList.js
+++ b/console/src/components/DestinationList/DestinationList.js
@@ -25,6 +25,7 @@ const DestinationList = kind({
 	render: ({destinations, title, ...rest}) => {
 		delete rest.component;
 		delete rest.onSetDestination;
+		delete rest.positions;
 
 		return (
 			<Column {...rest}>

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -51,7 +51,9 @@ const WelcomePopupBase = kind({
 	handlers: {
 		handleClose: handle(
 			(ev, {proposedDestination, setDestination}) => {
-				setDestination({destination: proposedDestination});
+				if (proposedDestination) {
+					setDestination({destination: proposedDestination});
+				}
 				return true;
 			},
 			forward('onClose')


### PR DESCRIPTION
Cleaning up:
1) There is some prop bleed in `DestinationList` that is unexpectedly appended to the dom
2) There is an error that will crash the demo when attempting to close the welcome screen without first selecting a destination from the `DestinationList`. This is a result of syncing the destination route without first validating the `proposedDestination` value. Issue introduced in: https://github.com/enactjs/agate-apps/pull/102/commits/5adf211e0a264b09dcb8b2587bf60f8bceeaabd9