### PR TITLE
Optimize welcome panel performance

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -76,8 +76,6 @@ const AppBase = kind({
 		updateSkin,
 		layoutArrangeableToggle,
 		layoutArrangeable,
-		onNextWelcomeView,
-		onPreviousWelcomeView,
 		onTogglePopup,
 		onToggleBasicPopup,
 		onToggleDateTimePopup,
@@ -91,7 +89,6 @@ const AppBase = kind({
 		showUserSelectionPopup,
 		showWelcomePopup,
 		skinName,
-		welcomeIndex,
 		...rest
 	}) => {
 		delete rest.accent;
@@ -195,10 +192,7 @@ const AppBase = kind({
 					<DateTimePicker onClose={onToggleDateTimePopup} />
 				</Popup>
 				<WelcomePopup
-					index={welcomeIndex}
 					onClose={onToggleWelcomePopup}
-					onNextView={onNextWelcomeView}
-					onPreviousView={onPreviousWelcomeView}
 					onSendVideo={sendVideo}
 					open={showWelcomePopup}
 				/>
@@ -219,17 +213,8 @@ const AppState = hoc((configHoc, Wrapped) => {
 				showDateTimePopup: false,
 				showUserSelectionPopup: false,
 				showAppList: false,
-				showWelcomePopup: true,
-				welcomeIndex: 0
+				showWelcomePopup: true
 			};
-		}
-
-		onNextWelcomeView = () => {
-			this.setState((state) => ({welcomeIndex: state.welcomeIndex + 1}));
-		}
-
-		onPreviousWelcomeView = () => {
-			this.setState((state) => ({welcomeIndex: state.welcomeIndex - 1}));
 		}
 
 		onSelect = handle(
@@ -272,8 +257,6 @@ const AppState = hoc((configHoc, Wrapped) => {
 					accent={colorAccent}
 					highlight={colorHighlight}
 					index={this.state.index}
-					onNextWelcomeView={this.onNextWelcomeView}
-					onPreviousWelcomeView={this.onPreviousWelcomeView}
 					onSelect={this.onSelect}
 					onTogglePopup={this.onTogglePopup}
 					onToggleBasicPopup={this.onToggleBasicPopup}
@@ -288,7 +271,6 @@ const AppState = hoc((configHoc, Wrapped) => {
 					showWelcomePopup={this.state.showWelcomePopup}
 					skin={skin}
 					skinName={skin}
-					welcomeIndex={this.state.welcomeIndex}
 				/>
 			);
 		}

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -31,6 +31,7 @@ const WelcomePopupBase = kind({
 		onPreviousView: PropTypes.func,
 		onSendVideo: PropTypes.func,
 		onSetDestination: PropTypes.func,
+		onTransition: PropTypes.func,
 		positions: PropTypes.array,
 		profileName: PropTypes.string,
 		proposedDestination: propTypeLatLonList,
@@ -58,9 +59,14 @@ const WelcomePopupBase = kind({
 			},
 			forward('onClose')
 		),
-		selectUserAndContinue: handle(
-			forward('updateUser'),
-			forward('onNextView')
+		handleTransition: handle(
+			(ev, {index, selected, updateUser}) => {
+				if (index === 1) {
+					updateUser({selected});
+				}
+				return true;
+			},
+			forward('onTransition')
 		)
 	},
 
@@ -76,11 +82,12 @@ const WelcomePopupBase = kind({
 
 	render: ({
 		handleClose,
+		handleTransition,
 		index,
+		onNextView,
 		onPreviousView,
 		onSendVideo,
 		onSetDestination,
-		selectUserAndContinue,
 		positions,
 		profileName,
 		proposedDestination,
@@ -88,14 +95,14 @@ const WelcomePopupBase = kind({
 		...rest
 	}) => {
 		delete rest.onClose;
-		delete rest.onNextView;
+		delete rest.onTransition;
 		delete rest.updateUser;
 		delete rest.setDestination;
 		delete rest.userId;
 
 		return (
 			<FullscreenPopup {...rest}>
-				<Panels index={index} enteringDelay={100} enteringProp="hideChildren">
+				<Panels index={index} enteringProp="hideChildren" onTransition={handleTransition}>
 					<Panel>
 						<Column align="stretch center">
 							<Cell component={Divider} startSection shrink>User Selection</Cell>
@@ -104,7 +111,7 @@ const WelcomePopupBase = kind({
 									component={Group}
 									childComponent={Cell}
 									itemProps={{component: LabeledIconButton, shrink: true, icon: 'user'}}
-									onSelect={selectUserAndContinue}
+									onSelect={onNextView}
 									select="radio"
 									selectedProp="selected"
 									wrap
@@ -115,6 +122,7 @@ const WelcomePopupBase = kind({
 							</Cell>
 						</Column>
 					</Panel>
+					<Panel />
 					<Panel>
 						<Column>
 							<Cell size="20%">
@@ -159,6 +167,7 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 		constructor (props) {
 			super(props);
 			this.state = {
+				index: 0,
 				positions: [
 					{lat: 37.788818, lon: -122.404568}, // LG office
 					{lat: 37.791356, lon: -122.400823}, // Blue Bottle Coffee
@@ -166,7 +175,8 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 					{lat: 37.7908574786, lon: -122.399391029},
 					{lat: 37.786116, lon: -122.402140}
 				],
-				destination: null
+				destination: null,
+				selected: null
 			};
 		}
 
@@ -175,14 +185,31 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 			this.setState(({positions}) => ({destination: [positions[index]]}));
 		}
 
+		onNextView = ({selected}) => {
+			this.setState((state) => ({index: ++state.index, selected}));
+		}
+
+		onPreviousView = () => {
+			this.setState({index: 0});
+		}
+
+		onTransition = () => {
+			this.setState(({index}) => index === 1 ? {index: ++index} : null);
+		}
+
 		render () {
-			const {destination, positions} = this.state;
+			const {destination, index, positions} = this.state;
 			return (
 				<Wrapped
 					{...this.props}
+					index={index}
+					onNextView={this.onNextView}
+					onPreviousView={this.onPreviousView}
 					onSetDestination={this.handleSetDestination}
+					onTransition={this.onTransition}
 					positions={positions}
 					proposedDestination={destination}
+					selected={this.state.selected}
 				/>
 			);
 		}

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -95,7 +95,7 @@ const WelcomePopupBase = kind({
 
 		return (
 			<FullscreenPopup {...rest}>
-				<Panels index={index}>
+				<Panels index={index} enteringDelay={100} enteringProp="hideChildren">
 					<Panel>
 						<Column align="stretch center">
 							<Cell component={Divider} startSection shrink>User Selection</Cell>

--- a/console/src/data/ServiceLayer.js
+++ b/console/src/data/ServiceLayer.js
@@ -234,6 +234,7 @@ const ServiceLayer = compose(
 		// },
 		setConnected: (connected) => {
 			updateAppState((state) => {
+				if (state.connections.serviceLayer === connected) return null;
 				state.connections.serviceLayer = connected;
 			});
 		},


### PR DESCRIPTION
**Issue**
Now that the welcome screen is populated, it's apparent that there is a performance issue when transitioning/animating from the user selection screen to the welcome screen. This is due to 2 main culprits:
1) A full panel of content is attempting to animate across the screen
2) The theme can change while transitioning if the selected user uses a different theme than the current one. Selecting a user who uses a different theme has the compound issue of a jarring theme change when we're not really expecting it.

**Fix**
1) We can use the `hideChildren` prop to hide the children during the transition, and they will fade-in when the transition has completed. This greatly helps the transition performance.
2) We can delay or change _when_ we apply a user's settings & theme. In order to avoid a jarring theme change on the user selection screen immediately before attempting to transition to the next theme, I've created a blank panel that we transition to. Once we transition to that panel, we can apply the new theme and then safely transition to the "welcome screen" without blocking performance. This will ultimately cause the transition to the "welcome screen" to take more total time, but we can adjust our timing if needed.

I think ultimately, we could attach this behavior to some sort of event (`onThemeChange`) that could aid in helping us know the current theme state before performing something that we wouldn't want a theme change to interfere with.

**Additional Considerations**
Since the `WelcomePopup` manages state now, I've moved its related state code out of `App` so that it is self-managed now.