### PR TITLE
PLAT-69809: Update Compact Music app design

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -217,7 +217,7 @@ const AppState = hoc((configHoc, Wrapped) => {
 				showDateTimePopup: false,
 				showUserSelectionPopup: false,
 				showAppList: false,
-				showWelcomePopup: true
+				showWelcomePopup: false
 			};
 		}
 

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -217,7 +217,7 @@ const AppState = hoc((configHoc, Wrapped) => {
 				showDateTimePopup: false,
 				showUserSelectionPopup: false,
 				showAppList: false,
-				showWelcomePopup: false
+				showWelcomePopup: true
 			};
 		}
 

--- a/console/src/components/CompactMusic/CompactMusic.js
+++ b/console/src/components/CompactMusic/CompactMusic.js
@@ -1,6 +1,6 @@
-import kind from '@enact/core/kind';
-import GridListImageItem from '@enact/agate/GridListImageItem';
 import Button from '@enact/agate/Button';
+import GridListImageItem from '@enact/agate/GridListImageItem';
+import kind from '@enact/core/kind';
 import Layout from '@enact/ui/Layout';
 import React from 'react';
 

--- a/console/src/components/CompactMusic/CompactMusic.js
+++ b/console/src/components/CompactMusic/CompactMusic.js
@@ -4,7 +4,7 @@ import Button from '@enact/agate/Button';
 import Layout from '@enact/ui/Layout';
 import React from 'react';
 
-import css from './CompactRadio.less';
+import css from './CompactMusic.less';
 
 const placeholder =
 	'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC' +
@@ -35,12 +35,12 @@ const PlaybackControls = kind({
 	}
 });
 
-const CompactRadioBase = kind({
-	name: 'CompactRadio',
+const CompactMusicBase = kind({
+	name: 'CompactMusic',
 
 	styles: {
 		css,
-		className: 'compactRadio'
+		className: 'compactMusic'
 	},
 
 	render: (props) => {
@@ -61,8 +61,8 @@ const CompactRadioBase = kind({
 	}
 });
 
-export default CompactRadioBase;
+export default CompactMusicBase;
 export {
-	CompactRadioBase as CompactRadio,
-	CompactRadioBase
+	CompactMusicBase as CompactMusic,
+	CompactMusicBase
 };

--- a/console/src/components/CompactMusic/CompactMusic.less
+++ b/console/src/components/CompactMusic/CompactMusic.less
@@ -1,4 +1,4 @@
-.compactRadio {
+.compactMusic {
 	height: 100%;
 
 	.album {

--- a/console/src/components/CompactMusic/CompactMusic.less
+++ b/console/src/components/CompactMusic/CompactMusic.less
@@ -6,17 +6,6 @@
 		height: 396px;
 	}
 
-	.title {
-		* {
-			justify-content: center;
-			text-align: center;
-		}
-	}
-
-	.row {
-		margin-bottom: 20px;
-	}
-
 	.playbackControls {
 		pointer-events: auto;
 	}

--- a/console/src/components/CompactMusic/package.json
+++ b/console/src/components/CompactMusic/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "CompactMusic.js"
+}

--- a/console/src/components/CompactRadio/CompactRadio.js
+++ b/console/src/components/CompactRadio/CompactRadio.js
@@ -1,5 +1,6 @@
 import kind from '@enact/core/kind';
 import GridListImageItem from '@enact/agate/GridListImageItem';
+import Button from '@enact/agate/Button';
 import Layout from '@enact/ui/Layout';
 import React from 'react';
 
@@ -10,6 +11,29 @@ const placeholder =
 	'9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHN0cm9rZT0iIzU1NSIgZmlsbD0iI2FhYSIg' +
 	'ZmlsbC1vcGFjaXR5PSIwLjIiIHN0cm9rZS1vcGFjaXR5PSIwLjgiIHN0cm9rZS13aWR0aD0iNiIgLz48L3N2Zz' +
 	'4NCg==';
+
+const PlaybackControls = kind({
+	name: 'PlaybackControls',
+
+	styles: {
+		css,
+		className: 'playbackControls'
+	},
+
+	render: (props) => {
+		return (
+			<Layout
+				{...props}
+				orientation="horizontal"
+				align="center center"
+			>
+				<Button icon="skipbackward" small />
+				<Button icon="play" />
+				<Button icon="skipforward" small />
+			</Layout>
+		);
+	}
+});
 
 const CompactRadioBase = kind({
 	name: 'CompactRadio',
@@ -23,9 +47,12 @@ const CompactRadioBase = kind({
 		return (
 			<Layout {...rest} align="center center">
 				<GridListImageItem
-					caption="The Song"
+					align="center center"
+					caption="The Title"
 					className={css.album}
 					placeholder={placeholder}
+					selectionOverlay={PlaybackControls}
+					selectionOverlayShowing
 					src={placeholder}
 					subCaption="The Album by The Artist"
 				/>

--- a/console/src/components/CompactRadio/CompactRadio.js
+++ b/console/src/components/CompactRadio/CompactRadio.js
@@ -43,9 +43,9 @@ const CompactRadioBase = kind({
 		className: 'compactRadio'
 	},
 
-	render: ({...rest}) => {
+	render: (props) => {
 		return (
-			<Layout {...rest} align="center center">
+			<Layout {...props} align="center center">
 				<GridListImageItem
 					align="center center"
 					caption="The Title"

--- a/console/src/components/CompactRadio/CompactRadio.js
+++ b/console/src/components/CompactRadio/CompactRadio.js
@@ -1,137 +1,41 @@
-import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 import kind from '@enact/core/kind';
-import {Row, Cell} from '@enact/ui/Layout';
-import Button from '@enact/agate/Button';
-import {LabeledItemBase} from '@enact/agate/LabeledItem';
-import IncrementSlider from '@enact/agate/IncrementSlider';
+import GridListImageItem from '@enact/agate/GridListImageItem';
+import Layout from '@enact/ui/Layout';
+import React from 'react';
 
 import css from './CompactRadio.less';
 
+const placeholder =
+	'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC' +
+	'9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHN0cm9rZT0iIzU1NSIgZmlsbD0iI2FhYSIg' +
+	'ZmlsbC1vcGFjaXR5PSIwLjIiIHN0cm9rZS1vcGFjaXR5PSIwLjgiIHN0cm9rZS13aWR0aD0iNiIgLz48L3N2Zz' +
+	'4NCg==';
+
 const CompactRadioBase = kind({
 	name: 'CompactRadio',
-
-	propTypes: {
-		changeStation: PropTypes.func,
-		currentStation: PropTypes.number
-	},
 
 	styles: {
 		css,
 		className: 'compactRadio'
 	},
 
-	handlers: {
-		onTune: (ev, {currentStation, changeStation}) => {
-			const action = ev.currentTarget.getAttribute('action');
-			let newStation;
-
-			if (action === 'tune-up') {
-				if (currentStation >= 108) {
-					newStation = 87.8;
-				} else {
-					newStation = (currentStation * 10 + 1) / 10;
-				}
-			} else if (action === 'tune-down') {
-				if (currentStation <= 87.8) {
-					newStation = 108;
-				} else {
-					newStation = (currentStation * 10 - 1) / 10;
-				}
-			} else if (action === 'scan-up') {
-				if (currentStation >= 108) {
-					newStation = 87.8;
-				} else {
-					newStation = (currentStation * 10 + 20) / 10;
-				}
-			} else if (action === 'scan-down') {
-				if (currentStation <= 87.8) {
-					newStation = 108;
-				} else {
-					newStation = (currentStation * 10 - 20) / 10;
-				}
-			}
-			changeStation(newStation);
-		}
-	},
-
-	render: ({currentStation, onTune, ...rest}) => {
-		delete rest.changeStation;
+	render: ({...rest}) => {
 		return (
-			<div {...rest}>
-				<LabeledItemBase className={css.title} label="Artist - Song">{currentStation} MHz</LabeledItemBase>
-				<Row align="center space-between" className={css.row}>
-					<Cell shrink>
-						<Button onClick={onTune} action="tune-down" icon="arrowsmallleft" />
-					</Cell>
-					Tune
-					<Cell shrink>
-						<Button onClick={onTune} action="tune-up" icon="arrowsmallright" />
-					</Cell>
-				</Row>
-				<IncrementSlider
-					defaultValue={15}
-					max={30}
-					min={0}
-					step={1}
+			<Layout {...rest} align="center center">
+				<GridListImageItem
+					caption="The Song"
+					className={css.album}
+					placeholder={placeholder}
+					src={placeholder}
+					subCaption="The Album by The Artist"
 				/>
-			</div>
+			</Layout>
 		);
 	}
 });
 
-class RadioCompact extends Component {
-	constructor () {
-		super();
-
-		this.state = {
-			currentPreset: 0,
-			currentStation: 87.8,
-			frequency: 'FM',
-			presets: [93.1, 105.1, 88.1, 92.1, 120.1]
-		};
-	}
-
-	changeFrequency = (frequency) => {
-		this.setState({frequency});
-	}
-
-	changePreset = (index) => {
-		this.setState({currentPreset: index});
-	}
-
-	changeStation = (station) => {
-		this.setState({currentStation: station});
-	}
-
-	updatePresets = (station, index) => {
-		this.setState(({presets}) => {
-			const updatedPresets = presets.map((presetStation, currentIndex) => {
-				if (parseInt(index) === currentIndex) {
-					return station;
-				} else {
-					return presetStation;
-				}
-			});
-
-			return {presets: updatedPresets};
-		});
-	}
-
-	render () {
-		return (
-			<CompactRadioBase
-				// changeFrequency={this.changeFrequency}
-				// changePreset={this.changePreset}
-				changeStation={this.changeStation}
-				// currentPreset={this.state.currentPreset}
-				currentStation={this.state.currentStation}
-				// frequency={this.state.frequency}
-				// presets={this.state.presets}
-				// updatePresets={this.updatePresets}
-			/>
-		);
-	}
-}
-
-export default RadioCompact;
+export default CompactRadioBase;
+export {
+	CompactRadioBase as CompactRadio,
+	CompactRadioBase
+};

--- a/console/src/components/CompactRadio/CompactRadio.less
+++ b/console/src/components/CompactRadio/CompactRadio.less
@@ -1,4 +1,11 @@
 .compactRadio {
+	height: 100%;
+
+	.album {
+		width: 300px;
+		height: 396px;
+	}
+
 	.title {
 		* {
 			justify-content: center;

--- a/console/src/components/CompactRadio/CompactRadio.less
+++ b/console/src/components/CompactRadio/CompactRadio.less
@@ -16,4 +16,8 @@
 	.row {
 		margin-bottom: 20px;
 	}
+
+	.playbackControls {
+		pointer-events: auto;
+	}
 }

--- a/console/src/components/CompactRadio/package.json
+++ b/console/src/components/CompactRadio/package.json
@@ -1,3 +1,0 @@
-{
-	"main": "CompactRadio.js"
-}

--- a/console/src/views/Home.js
+++ b/console/src/views/Home.js
@@ -10,7 +10,7 @@ import AppContextConnect from '../App/AppContextConnect';
 // import CompactHvac from '../components/CompactHVAC';
 import CompactMap from '../components/CompactMap';
 import CompactMultimedia from '../components/CompactMultimedia';
-import CompactRadio from '../components/CompactRadio';
+import CompactMusic from '../components/CompactMusic';
 import CompactWeather from '../components/CompactWeather';
 
 import css from './Home.less';
@@ -137,7 +137,7 @@ const Home = kind({
 		<Panel {...rest}>
 			<HomeLayout arrangeable={arrangeable}>
 				<small1><CompactWeather /></small1>
-				<small2><CompactRadio /></small2>
+				<small2><CompactMusic /></small2>
 				<medium><CompactMultimedia onSendVideo={onSendVideo} /></medium>
 				<large><CompactMap onSelect={onSelect} /></large>
 			</HomeLayout>


### PR DESCRIPTION
* Updated the Compact Radio app to only include an album
* We don't have UX designs for the "medium" or "large" music app so I've not added support for `ResponsiveBox` nor either of those layouts.
* I added previous/play/next buttons over the album art which wasn't in the UX but seemed reasonable