### PR TITLE
Add CompactHeater component, using it in user1 welcome screen via config

### DIFF
--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -47,6 +47,9 @@ const defaultUserSettings = {
 		rightHeat: false,
 		rightTemp: 0
 	},
+	components: {
+		welcome: {}
+	},
 	colorAccent: '#cccccc',
 	colorHighlight: '#66aabb',
 	fontSize: 0,

--- a/console/src/App/userPresetsForDemo.json
+++ b/console/src/App/userPresetsForDemo.json
@@ -20,6 +20,12 @@
 		},
 		"colorAccent": "#75d1f0",
 		"colorHighlight": "#259aa7",
+		"components": {
+			"welcome": {
+				"small1": "heater",
+				"small2": "multimedia"
+			}
+		},
 		"fontSize": 0,
 		"name": "Laura & Steve",
 		"skin": "carbon"
@@ -68,6 +74,12 @@
 		},
 		"colorAccent": "#cccccc",
 		"colorHighlight": "#566af0",
+		"components": {
+			"welcome": {
+				"small1": "weather",
+				"small2": "multimedia"
+			}
+		},
 		"fontSize": 0,
 		"name": "Thomas",
 		"skin": "titanium"
@@ -90,6 +102,12 @@
 			"recirculate": false,
 			"rightHeat": false,
 			"rightTemp": 0
+		},
+		"components": {
+			"welcome": {
+				"small1": "weather",
+				"small2": "multimedia"
+			}
 		},
 		"colorAccent": "#0359f0",
 		"colorHighlight": "#f08c21",

--- a/console/src/components/CompactHeater/CompactHeater.js
+++ b/console/src/components/CompactHeater/CompactHeater.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Divider from '@enact/agate/Divider';
+import ToggleButton from '@enact/agate/ToggleButton';
+import kind from '@enact/core/kind';
+import {Cell, Column, Row} from '@enact/ui/Layout';
+
+import AppStateConnect from '../../App/AppContextConnect';
+
+import css from './CompactHeater.less';
+
+const CompactHeaterBase = kind({
+	name: 'CompactHeater',
+
+	propTypes: {
+		leftHeat: PropTypes.bool,
+		onToggleLeftHeater: PropTypes.func,
+		onToggleRightHeater: PropTypes.func,
+		rightHeat: PropTypes.bool
+	},
+
+	styles: {
+		css,
+		className: 'compactHeater'
+	},
+
+	computed: {
+		leftStatus: ({leftHeat}) => leftHeat ? 'on' : 'off',
+		rightStatus: ({rightHeat}) => rightHeat ? 'on' : 'off'
+	},
+
+	render: ({leftHeat, leftStatus, onToggleLeftHeater, onToggleRightHeater, rightHeat, rightStatus, ...rest}) => (
+		<div {...rest}>
+			<Column>
+				<Cell component={Divider} shrink>Heated Seats</Cell>
+				<Cell>
+					<Row align="center space-around">
+						<Cell shrink><ToggleButton icon="heatseatleft" onClick={onToggleLeftHeater} selected={leftHeat} underline /></Cell>
+						<Cell shrink><ToggleButton icon="heatseatright" onClick={onToggleRightHeater} selected={rightHeat} underline /></Cell>
+					</Row>
+				</Cell>
+				<Cell>
+					<Row align="center space-around">
+						<Cell shrink>Left: {leftStatus}</Cell>
+						<Cell shrink>Right: {rightStatus}</Cell>
+					</Row>
+				</Cell>
+			</Column>
+		</div>
+	)
+});
+
+const CompactHeater = AppStateConnect(({userSettings: {climate}, updateAppState}) => ({
+	leftHeat: (climate && climate.leftHeat),
+	rightHeat: (climate && climate.rightHeat),
+	onToggleLeftHeater: () => {
+		updateAppState((state) => {
+			const heat = state.userSettings.climate.leftHeat;
+			state.userSettings.climate.leftHeat = !heat;
+		});
+	},
+	onToggleRightHeater: () => {
+		updateAppState((state) => {
+			const heat = state.userSettings.climate.rightHeat;
+			state.userSettings.climate.rightHeat = !heat;
+		});
+	}
+}))(CompactHeaterBase);
+
+export default CompactHeater;

--- a/console/src/components/CompactHeater/CompactHeater.less
+++ b/console/src/components/CompactHeater/CompactHeater.less
@@ -1,0 +1,3 @@
+.compactHeater {
+	height: 100%;
+}

--- a/console/src/components/CompactHeater/package.json
+++ b/console/src/components/CompactHeater/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "CompactHeater.js"
+}

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import AppContextConnect from '../../App/AppContextConnect';
+import CompactHeater from '../CompactHeater';
 import CompactMultimedia from '../CompactMultimedia';
 import CompactWeather from '../CompactWeather';
 import DestinationList from '../DestinationList';
@@ -21,10 +22,28 @@ import {propTypeLatLonList} from '../../data/proptypes';
 
 import css from './WelcomePopup.less';
 
+const getCompactComponent = ({components, key, onSendVideo}) => {
+	let Component;
+
+	switch (components[key]) {
+		case 'multimedia':
+			Component = (<CompactMultimedia onSendVideo={onSendVideo} />);
+			break;
+		case 'heater':
+			Component = (<CompactHeater />);
+			break;
+		default:
+			Component = (<CompactWeather />);
+	}
+
+	return (<Cell>{Component}</Cell>);
+};
+
 const WelcomePopupBase = kind({
 	name: 'WelcomePopup',
 
 	propTypes: {
+		components: PropTypes.object,
 		index: PropTypes.number,
 		onCancelSelect: PropTypes.func,
 		onClose: PropTypes.func,
@@ -73,7 +92,9 @@ const WelcomePopupBase = kind({
 				users.push(usersList[user]);
 			}
 			return users;
-		}
+		},
+		small1Component: (props) => getCompactComponent({...props, key: 'small1'}),
+		small2Component: (props) => getCompactComponent({...props, key: 'small2'})
 	},
 
 	render: ({
@@ -82,15 +103,18 @@ const WelcomePopupBase = kind({
 		index,
 		onCancelSelect,
 		onSelectUser,
-		onSendVideo,
 		onSetDestination,
 		positions,
 		profileName,
 		proposedDestination,
+		small1Component: Small1Component,
+		small2Component: Small2Component,
 		usersList,
 		...rest
 	}) => {
+		delete rest.components;
 		delete rest.onClose;
+		delete rest.onSendVideo;
 		delete rest.onShowWelcome;
 		delete rest.updateUser;
 		delete rest.setDestination;
@@ -138,12 +162,8 @@ const WelcomePopupBase = kind({
 									<Cell component={MapCore} proposedDestination={proposedDestination} size="40%" />
 									<Cell size="35%">
 										<Column>
-											<Cell shrink>
-												<CompactWeather />
-											</Cell>
-											<Cell>
-												<CompactMultimedia onSendVideo={onSendVideo} />
-											</Cell>
+											{Small1Component}
+											{Small2Component}
 										</Column>
 									</Cell>
 								</Row>
@@ -223,7 +243,7 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 });
 
 const WelcomePopup = AppContextConnect(({getUserNames, updateAppState, userId, userSettings}) => ({
-	usersList: getUserNames(),
+	components: (userSettings.components && {...userSettings.components.welcome}),
 	profileName: userSettings.name,
 	setDestination: ({destination}) => {
 		updateAppState((state) => {
@@ -235,7 +255,8 @@ const WelcomePopup = AppContextConnect(({getUserNames, updateAppState, userId, u
 			state.userId = selected + 1;
 		});
 	},
-	userId
+	userId,
+	usersList: getUserNames()
 }))(WelcomePopupState(WelcomePopupBase));
 
 export default WelcomePopup;


### PR DESCRIPTION
This PR adds the following:

- `CompactHeater` component, which displays a couple of toggle buttons that represent the left/right heated seats
- User settings config to apply specific components to the welcome screen per user. Currently only user1 uses the `CompactHeater` component