### PR TITLE
PLAT-69892 - Add support for dynamic IP 

### DIFF
--- a/communication-server/package.json
+++ b/communication-server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon src/app.js"
+    "start": "node src/app.js",
+    "watch": "nodemon src/app.js"
   },
   "author": "",
   "license": "ISC",

--- a/components/package.json
+++ b/components/package.json
@@ -8,6 +8,7 @@
     "@enact/core": "^2.1.1",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
+    "query-string": "^6.1.0",
     "socket.io-client": "^2.1.1",
     "webrtc-ips": "^0.1.3"
   }

--- a/components/urlParser.js
+++ b/components/urlParser.js
@@ -5,7 +5,7 @@ const getValue = (key, value) => {
 	const parsed = qs.parse(window.location.search);
 
 	if (parsed[key]) {
-		if (typeof window !== undefined) {
+		if (typeof window !== 'undefined') {
 			window.localStorage.setItem(key, parsed[key]);
 		}
 	}
@@ -28,7 +28,7 @@ const getConfig = (config) => {
 	}
 
 	const stringified = qs.stringify({...parsed, ...newConfig});
-	if (typeof window !== undefined) {
+	if (typeof window !== 'undefined') {
 		window.history.replaceState('', '', `/?${stringified}`);
 	}
 

--- a/components/urlParser.js
+++ b/components/urlParser.js
@@ -1,11 +1,13 @@
 import qs from 'query-string';
 
-// If value is in url as a param use that, if not pull from localstorage, if not fallback to value
+// If value is in url as a param use that, if not pull from localstorage, if not fallback to config value
 const getValue = (key, value) => {
 	const parsed = qs.parse(window.location.search);
 
 	if (parsed[key]) {
-		window.localStorage.setItem(key, parsed[key]);
+		if (typeof window !== undefined) {
+			window.localStorage.setItem(key, parsed[key]);
+		}
 	}
 
 	const newValue = parsed[key] || window.localStorage.getItem(key) || value;
@@ -26,7 +28,9 @@ const getConfig = (config) => {
 	}
 
 	const stringified = qs.stringify({...parsed, ...newConfig});
-	window.history.replaceState('', '', `/?${stringified}`);
+	if (typeof window !== undefined) {
+		window.history.replaceState('', '', `/?${stringified}`);
+	}
 
 	return newConfig;
 };

--- a/components/urlParser.js
+++ b/components/urlParser.js
@@ -1,0 +1,37 @@
+import qs from 'query-string';
+
+
+const getValue = (key, value) => {
+	const parsed = qs.parse(window.location.search);
+	console.log(parsed)
+	if (parsed[key]) {
+		window.localStorage.setItem(key, parsed[key]);
+	}
+
+	const newValue = parsed[key] || window.localStorage.getItem(key) || value;
+
+	// Set new value to url
+	parsed[key] = newValue;
+
+	return newValue;
+};
+
+// If value is in url as a param use that, if not pull from localstorage, if not fallback to value
+const getConfig = (config) => {
+	let newConfig = {};
+	const parsed = qs.parse(window.location.search);
+	for (let key in config) {
+		const value = config[key];
+
+		newConfig[key] = getValue(key, value);
+	}
+
+	const stringified = qs.stringify({...parsed, ...newConfig});
+	window.history.replaceState('', '', `/?${stringified}`);
+
+	return newConfig;
+};
+
+export {
+	getConfig
+};

--- a/components/urlParser.js
+++ b/components/urlParser.js
@@ -1,9 +1,9 @@
 import qs from 'query-string';
 
-
+// If value is in url as a param use that, if not pull from localstorage, if not fallback to value
 const getValue = (key, value) => {
 	const parsed = qs.parse(window.location.search);
-	console.log(parsed)
+
 	if (parsed[key]) {
 		window.localStorage.setItem(key, parsed[key]);
 	}
@@ -16,7 +16,6 @@ const getValue = (key, value) => {
 	return newValue;
 };
 
-// If value is in url as a param use that, if not pull from localstorage, if not fallback to value
 const getConfig = (config) => {
 	let newConfig = {};
 	const parsed = qs.parse(window.location.search);

--- a/console/config.sample.js
+++ b/console/config.sample.js
@@ -1,11 +1,13 @@
-export default {
+import {getConfig} from '../components/urlParser';
+
+const config = {
 	// For weather to work, you'll need to get an OpenWeatherMaps.org API key.
 	// Here's where: https://openweathermap.org/appid
 	weatherApiKey: '<Insert your OpenWeatherMaps API key here>',
 
 	// Agate Console uses mapbox for its maps. You can obtain your API key by
 	// visiting the following site: https://www.mapbox.com/help/define-access-token/
-	mapApiKey: '<Insert your MapBox API key here>',
+	mapApiKey: '<Insert your OpenWeatherMaps API key here>',
 
 	// Point this variable to the hostname (IP, domain, or localhost) of the services layer
 	// The ROS server that we'll subscribe to to get service topics.
@@ -18,3 +20,7 @@ export default {
 	// Ex: localhost:3000
 	communicationServerHost: 'localhost:3000'
 };
+
+const newConfig = getConfig(config);
+
+export default newConfig;

--- a/console/src/index.js
+++ b/console/src/index.js
@@ -16,7 +16,13 @@ if (typeof window !== 'undefined') {
 	const index = parseInt(args.index || 0);
 	const skin = args.skin;
 
-	const onSelect = (ev) => window.history.pushState(ev, '', `?index=${ev.index}`);
+	const onSelect = (ev) => {
+		const params = qs.parse(window.location.search);
+		params.index = ev.index;
+		const stringified = qs.stringify(params);
+
+		window.history.pushState(ev, '', `/?${stringified}`);
+	};
 
 	appElement = (
 		<AppContextProvider defaultSkin={skin}>

--- a/copilot/config.sample.js
+++ b/copilot/config.sample.js
@@ -1,6 +1,12 @@
-export default {
+import {getConfig} from '../components/urlParser';
+
+const config = {
 	// The host for the communication server that allows console to talk to co-pilot
 	// A "host" is the combination of the hostname (like localhost) and a port number.
 	// Ex: localhost:3000 or IpAddress:Port
 	communicationServerHost: 'localhost:3000'
 };
+
+const newConfig = getConfig(config);
+
+export default newConfig;


### PR DESCRIPTION
Added logic to use URL params to override the config. This is done because if IPs change or API keys expire, we don't need rebuild applications we can just change them from the URL.

I'm also saving it to localStorage incase we need to recover them.

Currently the order goes url > localStorage > config value. We could change the ordering, but I think this way made the most sense.