### PR TITLE
PLAT-71025: Welcome screen - Change “continue” button text to “Let's go”

### DIFF
--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -210,7 +210,7 @@ const WelcomePopupBase = kind({
 									<Cell className={css.smallComponent}>
 										{Small2Component}
 									</Cell>
-									<Cell component={Button} onClick={handleClose} shrink>Continue</Cell>
+									<Cell component={Button} onClick={handleClose} shrink>{"Let's Go!"}</Cell>
 								</Column>
 							</Cell>
 							<Cell>
@@ -259,6 +259,14 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 			this.setState({index: 0});
 		}
 
+		handleContinue = () => {
+			this.props.updateAppState((state) => {
+				if (state.navigation.autonomous) {
+					state.navigation.navigating = true;
+				}
+			});
+		}
+
 		handleShowWelcome = () => {
 			this.setState(({index}) => index === 1 ? {index: ++index} : null);
 		}
@@ -284,6 +292,7 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 					index={index}
 					onSelectUser={this.handleSelectUser}
 					onCancelSelect={this.handleCancelSelect}
+					onContinue={this.handleContinue}
 					onShowWelcome={this.handleShowWelcome}
 					selected={this.state.selected}
 					updateUser={this.updateUser}


### PR DESCRIPTION
Updated “continue” button text to “Let's go”, and also to start navigation by setting the app state `navigating` to `true` when `auto` is selected.

PLAT-71025