### PR TITLE
PLAT-71119: Populate userList state correctly on first launch

### DIFF
--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -99,17 +99,16 @@ class AppContextProvider extends Component {
 	}
 
 	componentWillMount () {
-		const usersList = this.getUserNames();
-
-		this.updateAppState((state) => {
-			state.usersList = usersList;
-		});
 		// If there are no users in the list when we load for the first time, stamp some out and prepare the system.
-		if (Object.keys(usersList).length <= 0) {
+		if (this.getAllSavedUserIds().length <= 0) {
 			this.resetAll();
 		} else {
 			this.updateUserSettings(['arrangements', 'arrangeable'], false);
 		}
+
+		this.updateAppState((state) => {
+			state.usersList = this.getUserNames();
+		});
 
 		this.setUserSettings(this.state.userId);
 		this.setLocation();


### PR DESCRIPTION
On first launch (when no saved users exist in `localStorage`), the `usersList` state isn't populated correctly. Currently we:
- store the saved users into a variable
- if no users are found, we save new users to `localStorage`
- save the original (empty) saved users value into state

I ultimately needed to change the order of operations here, so that we store the new users into our state.
