### PR TITLE
PLAT-71223: Override 'arrangement' with the correct user setting

### DIFF
--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import produce from 'immer';
-import {assocPath, mergeDeepRight, path} from 'ramda';
+import {assocPath, mergeDeepRight, omit, path} from 'ramda';
 
 import appConfig from '../App/configLoader';
 import userPresetsForDemo from './userPresetsForDemo';
@@ -167,7 +167,7 @@ class AppContextProvider extends Component {
 		const userSettings = this.loadUserSettings(userId);
 
 		// Apply a consistent (predictable) set of object keys for consumers, merging in new keys since their last visit
-		return mergeDeepRight(this.state.userSettings, userSettings);
+		return mergeDeepRight(omit(['arrangements'], this.state.userSettings), userSettings);
 	}
 
 	loadUserSettings = (userId) => {


### PR DESCRIPTION
When changing resetting current user setting, the arrangement changes do not reset to default value. This is due to how `arrangement` object gets merged. We should always respect the loaded user setting and ignore the current state.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>