### PR TITLE
PLAT-71037: Show external screen option only when more than 1 exists

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -192,7 +192,7 @@ const AppBase = kind({
 						arrangeable={layoutArrangeable}
 						onSelect={onSelect}
 					/>
-					<Multimedia onSendVideo={sendVideo} />
+					<Multimedia onSendVideo={sendVideo} screenIds={[0, 1, 2]} />
 				</TabbedPanels>
 				<UserSelectionPopup
 					onClose={onToggleUserSelectionPopup}

--- a/console/src/components/CompactMultimedia/CompactMultimedia.js
+++ b/console/src/components/CompactMultimedia/CompactMultimedia.js
@@ -11,8 +11,6 @@ import {MultimediaDecorator, ResponsiveVirtualList} from '../../views/Multimedia
 
 import css from './CompactMultimedia.less';
 
-const screenIds = [1, 2];
-
 const CompactMultimediaBase = kind({
 	name: 'CompactMultimedia',
 
@@ -46,7 +44,7 @@ const CompactMultimediaBase = kind({
 		}
 	},
 
-	render: ({containerShape, listCellSize, onClosePopup, onSelectVideo, onSendVideo, rearScreen1, showPopup, videos, ...rest}) => {
+	render: ({containerShape, listCellSize, onClosePopup, onSelectVideo, onSendVideo, rearScreen1, screenIds, showPopup, videos, ...rest}) => {
 		delete rest.adContent;
 		delete rest.showAd;
 
@@ -59,7 +57,7 @@ const CompactMultimediaBase = kind({
 					onSelect={onSendVideo}
 					open={showPopup}
 					screenIds={screenIds}
-					showAllScreens
+					showAllScreens={showPopup}
 				/>
 				<WidgetBase
 					{...rest}

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -30,7 +30,7 @@ const getCompactComponent = ({components, key, onSendVideo}) => {
 
 	switch (components[key]) {
 		case 'multimedia':
-			Component = (<CompactMultimedia onSendVideo={onSendVideo} />);
+			Component = (<CompactMultimedia onSendVideo={onSendVideo} screenIds={[1, 2]} />);
 			break;
 		case 'heater':
 			Component = (<CompactHeater />);

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -30,7 +30,7 @@ const getCompactComponent = ({components, key, onSendVideo}) => {
 
 	switch (components[key]) {
 		case 'multimedia':
-			Component = (<CompactMultimedia onSendVideo={onSendVideo} screenIds={[1, 2]} />);
+			Component = (<CompactMultimedia onSendVideo={onSendVideo} screenIds={[1]} />);
 			break;
 		case 'heater':
 			Component = (<CompactHeater />);

--- a/console/src/views/Home.js
+++ b/console/src/views/Home.js
@@ -210,7 +210,7 @@ const Home = kind({
 
 				<small1><CompactWeather icon="climate" onExpand={onCompactExpand} /></small1>
 				<small2><CompactMusic icon="audio" onExpand={onCompactExpand} /></small2>
-				<medium><CompactMultimedia icon="resumeplay" onExpand={onCompactExpand} onSendVideo={onSendVideo} /></medium>
+				<medium><CompactMultimedia icon="resumeplay" onExpand={onCompactExpand} onSendVideo={onSendVideo} screenIds={[1]} /></medium>
 				<large><CompactMap icon="compass" onExpand={onCompactExpand} /></large>
 			</HomeLayout>
 		</Panel>

--- a/console/src/views/Multimedia.js
+++ b/console/src/views/Multimedia.js
@@ -298,7 +298,7 @@ const MultimediaDecorator = hoc(defaultConfig, (configHoc, Wrapped) => {
 			const {adContent, showAd, showPopup, url, videos} = this.state;
 
 			const props = {
-				...this.props, 
+				...this.props,
 				adContent,
 				onClosePopup: this.onClosePopup,
 				onSelectVideo: this.onSelectVideo,

--- a/console/src/views/Multimedia.js
+++ b/console/src/views/Multimedia.js
@@ -22,8 +22,6 @@ import youtubeVideos from '../data/youtubeapi.json';
 
 import css from './Multimedia.less';
 
-const screenIds = [0, 1, 2];
-
 const IFrame = kind({
 	name: 'IFrame',
 	render: (props) => {
@@ -158,6 +156,7 @@ const MultimediaBase = kind({
 		onClosePopup: PropTypes.func,
 		onSelectVideo: PropTypes.func,
 		onSendVideo: PropTypes.func,
+		screenIds: PropTypes.array,
 		showAd: PropTypes.bool,
 		showPopup: PropTypes.bool,
 		url: PropTypes.string,
@@ -179,6 +178,7 @@ const MultimediaBase = kind({
 		onClosePopup,
 		onSelectVideo,
 		onSendVideo,
+		screenIds,
 		url,
 		videos,
 		...rest
@@ -190,7 +190,7 @@ const MultimediaBase = kind({
 					onSelect={onSendVideo}
 					open={showPopup}
 					screenIds={screenIds}
-					showAllScreens
+					showAllScreens={showPopup}
 				/>
 				<Panel {...rest}>
 					<CustomLayout
@@ -231,6 +231,7 @@ const MultimediaDecorator = hoc(defaultConfig, (configHoc, Wrapped) => {
 		static propTypes = {
 			adContent: PropTypes.any,
 			onSendVideo: PropTypes.func,
+			screenIds: PropTypes.array,
 			showAd: PropTypes.bool
 		}
 
@@ -267,8 +268,14 @@ const MultimediaDecorator = hoc(defaultConfig, (configHoc, Wrapped) => {
 		};
 
 		onSelectVideo = (video) => () => {
+			const {screenIds} = this.props;
 			this.selectedVideo = video;
-			this.onOpenPopup();
+
+			if (screenIds.length > 1) {
+				this.onOpenPopup();
+			} else {
+				this.onSendVideo({screenId: screenIds[0]});
+			}
 		};
 
 		onSendVideo = ({screenId}) => {
@@ -291,7 +298,7 @@ const MultimediaDecorator = hoc(defaultConfig, (configHoc, Wrapped) => {
 			const {adContent, showAd, showPopup, url, videos} = this.state;
 
 			const props = {
-				...this.props,
+				...this.props, 
 				adContent,
 				onClosePopup: this.onClosePopup,
 				onSelectVideo: this.onSelectVideo,


### PR DESCRIPTION
When only 1 external screen is connected, we want to avoid the `ScreenSelectionPopup`, causing an additional click - rather immediately issuing the `onSendVideo` method.

In the app, we use 3 instances of multimedia (welcome, home, and multimedia screens). Each instance uses a different amount/config of screen (for testing purposes?). I've decided to keep these as-is for now while testing these different behaviors, but added prop support for them - which was needed by `MediaDecorator` to perform the correct behavior on selection. This gives us more flexibility for now, but I assume we'll want a single source for our `screenIds` before long.

I also opted to base the value of `showAllScreens` on whether or not the popup is open per instance, rather than changing the behavior in `ScreenSelectionPopup`, in order to keep the flexibility of that component for additional/future use.