### PR TITLE
PLAT-70503: Fix car flickering while navigating

### DIFF
--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -151,6 +151,8 @@ const addCarLayer = ({coordinates, iconURL, map, orientation = 0}) => {
 				'layout': {
 					'icon-image': 'car',
 					'icon-size': 0.10,
+					'icon-allow-overlap': true,
+					'icon-ignore-placement': true,
 					// rotation of the car
 					'icon-rotate': orientation
 				}
@@ -364,7 +366,7 @@ class MapCoreBase extends React.Component {
 						break;
 					}
 					case 'positionCar': {
-						this.updateCarLayer({location: actions[action]});
+						window.requestAnimationFrame(() => this.updateCarLayer({location: actions[action]}));
 						break;
 					}
 					case 'center': {

--- a/console/src/data/ServiceLayer.js
+++ b/console/src/data/ServiceLayer.js
@@ -295,10 +295,7 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 			delete rest.autonomous;
 			delete rest.location;
 			delete rest.navigating;
-			delete rest.navigation;
 			delete rest.setConnected;
-			delete rest.setConnected;
-			delete rest.setLocation;
 			delete rest.setLocation;
 			delete rest.updateAppState;
 			delete rest.updateDestination;


### PR DESCRIPTION
When a car collides with another "symbol", an icon or a text label, the car would disappear. `icon-allow-overlap` property allows the icon, to overlap.
https://www.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-icon-allow-overlap

`icon-ignore-placement` is not directly related, but I noticed that with a value of `false` the label of the streets would fade out as the car goes through the line, or the street. I've set it to `true` for a potential perf loss.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>