### PR TITLE
PLAT-71225: Remove user selection popup and restart demo from Laura's

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -19,7 +19,7 @@ import ServiceLayer from '../data/ServiceLayer';
 import ProfileDrawer from '../components/ProfileDrawer';
 import UserAvatar from '../components/UserAvatar';
 import Clock from '../components/Clock';
-// import WelcomePopup from '../components/WelcomePopup';
+import WelcomePopup from '../components/WelcomePopup';
 import AppList from '../views/AppList';
 import Home from '../views/Home';
 import Hvac from '../views/HVAC';
@@ -83,11 +83,11 @@ const AppBase = kind({
 				state.appState.showDateTimePopup = !state.appState.showDateTimePopup;
 			});
 		},
-		// onToggleWelcomePopup: (ev, {updateAppState}) => {
-		// 	updateAppState((state) => {
-		// 		state.appState.showWelcomePopup = !state.appState.showWelcomePopup;
-		// 	});
-		// },
+		onToggleWelcomePopup: (ev, {updateAppState}) => {
+			updateAppState((state) => {
+				state.appState.showWelcomePopup = !state.appState.showWelcomePopup;
+			});
+		},
 		onTogglePopup: (ev, {updateAppState}) => {
 			updateAppState((state) => {
 				state.appState.showPopup = !state.appState.showPopup;
@@ -102,7 +102,7 @@ const AppBase = kind({
 			onSelect({index: 0});
 			updateAppState((state) => {
 				state.userId = 1;
-				// state.appState.showWelcomePopup = true;
+				state.appState.showWelcomePopup = true;
 				state.appState.showUserSelectionPopup = false;
 				state.appState.showProfileEdit = false;
 			});
@@ -118,7 +118,7 @@ const AppBase = kind({
 		onToggleDateTimePopup,
 		onTogglePopup,
 		onToggleProfileEdit,
-		// onToggleWelcomePopup,
+		onToggleWelcomePopup,
 		orientation,
 		resetPosition,
 		sendVideo,
@@ -126,7 +126,7 @@ const AppBase = kind({
 		showDateTimePopup,
 		showPopup,
 		showUserSelectionPopup,
-		// showWelcomePopup,
+		showWelcomePopup,
 		skinName,
 		userId,
 		...rest
@@ -233,12 +233,12 @@ const AppBase = kind({
 					</title>
 					<DateTimePicker onClose={onToggleDateTimePopup} />
 				</Popup>
-				{/* <WelcomePopup
+				<WelcomePopup
 					noAnimation
 					onClose={onToggleWelcomePopup}
 					onSendVideo={sendVideo}
 					open={showWelcomePopup}
-				/> */}
+				/>
 			</div>
 		);
 	}
@@ -281,7 +281,6 @@ const AppDecorator = compose(
 	ServiceLayer,
 	AppContextConnect(({appState, userSettings, userId, updateAppState}) => ({
 		accent: userSettings.colorAccent,
-		// showWelcomePopup: appState.showWelcomePopup,
 		highlight: userSettings.colorHighlight,
 		layoutArrangeable: userSettings.arrangements.arrangeable,
 		orientation: (userSettings.skin !== 'carbon') ? 'horizontal' : 'vertical',
@@ -290,6 +289,7 @@ const AppDecorator = compose(
 		showDateTimePopup: appState.showDateTimePopup,
 		showPopup: appState.showPopup,
 		showUserSelectionPopup: appState.showUserSelectionPopup,
+		showWelcomePopup: appState.showWelcomePopup,
 		skin: userSettings.skin,
 		skinName: userSettings.skin,
 		updateAppState,

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -19,7 +19,7 @@ import ServiceLayer from '../data/ServiceLayer';
 import ProfileDrawer from '../components/ProfileDrawer';
 import UserAvatar from '../components/UserAvatar';
 import Clock from '../components/Clock';
-import WelcomePopup from '../components/WelcomePopup';
+// import WelcomePopup from '../components/WelcomePopup';
 import AppList from '../views/AppList';
 import Home from '../views/Home';
 import Hvac from '../views/HVAC';
@@ -83,11 +83,11 @@ const AppBase = kind({
 				state.appState.showDateTimePopup = !state.appState.showDateTimePopup;
 			});
 		},
-		onToggleWelcomePopup: (ev, {updateAppState}) => {
-			updateAppState((state) => {
-				state.appState.showWelcomePopup = !state.appState.showWelcomePopup;
-			});
-		},
+		// onToggleWelcomePopup: (ev, {updateAppState}) => {
+		// 	updateAppState((state) => {
+		// 		state.appState.showWelcomePopup = !state.appState.showWelcomePopup;
+		// 	});
+		// },
 		onTogglePopup: (ev, {updateAppState}) => {
 			updateAppState((state) => {
 				state.appState.showPopup = !state.appState.showPopup;
@@ -98,11 +98,13 @@ const AppBase = kind({
 				state.appState.showBasicPopup = !state.appState.showBasicPopup;
 			});
 		},
-		onResetAll: (ev, {updateAppState}) => {
+		onResetAll: (ev, {onSelect, updateAppState}) => {
+			onSelect({index: 0});
 			updateAppState((state) => {
-				state.appState.index = 0;
-				state.appState.showWelcomePopup = true;
+				state.userId = 1;
+				// state.appState.showWelcomePopup = true;
 				state.appState.showUserSelectionPopup = false;
+				state.appState.showProfileEdit = false;
 			});
 		}
 	},
@@ -116,7 +118,7 @@ const AppBase = kind({
 		onToggleDateTimePopup,
 		onTogglePopup,
 		onToggleProfileEdit,
-		onToggleWelcomePopup,
+		// onToggleWelcomePopup,
 		orientation,
 		resetPosition,
 		sendVideo,
@@ -124,7 +126,7 @@ const AppBase = kind({
 		showDateTimePopup,
 		showPopup,
 		showUserSelectionPopup,
-		showWelcomePopup,
+		// showWelcomePopup,
 		skinName,
 		userId,
 		...rest
@@ -231,12 +233,12 @@ const AppBase = kind({
 					</title>
 					<DateTimePicker onClose={onToggleDateTimePopup} />
 				</Popup>
-				<WelcomePopup
+				{/* <WelcomePopup
 					noAnimation
 					onClose={onToggleWelcomePopup}
 					onSendVideo={sendVideo}
 					open={showWelcomePopup}
-				/>
+				/> */}
 			</div>
 		);
 	}
@@ -279,6 +281,7 @@ const AppDecorator = compose(
 	ServiceLayer,
 	AppContextConnect(({appState, userSettings, userId, updateAppState}) => ({
 		accent: userSettings.colorAccent,
+		// showWelcomePopup: appState.showWelcomePopup,
 		highlight: userSettings.colorHighlight,
 		layoutArrangeable: userSettings.arrangements.arrangeable,
 		orientation: (userSettings.skin !== 'carbon') ? 'horizontal' : 'vertical',
@@ -287,11 +290,10 @@ const AppDecorator = compose(
 		showDateTimePopup: appState.showDateTimePopup,
 		showPopup: appState.showPopup,
 		showUserSelectionPopup: appState.showUserSelectionPopup,
-		showWelcomePopup: appState.showWelcomePopup,
 		skin: userSettings.skin,
 		skinName: userSettings.skin,
-		userId,
-		updateAppState
+		updateAppState,
+		userId
 	})),
 	AppIndex,
 	AgateDecorator

--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -69,8 +69,8 @@ class AppContextProvider extends Component {
 				showDateTimePopup: false,
 				showPopup: false,
 				showProfileEdit: false,
-				showUserSelectionPopup: false
-				// showWelcomePopup: 'defaultShowWelcomePopup' in props ? Boolean(props.defaultShowWelcomePopup) : true
+				showUserSelectionPopup: false,
+				showWelcomePopup: 'defaultShowWelcomePopup' in props ? Boolean(props.defaultShowWelcomePopup) : true
 			},
 			userId: 1,
 			userSettings: this.getDefaultUserSettings(1, props),

--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import produce from 'immer';
-import {assocPath, mergeDeepRight, omit, path} from 'ramda';
+import {assocPath, equals, mergeDeepRight, omit, path} from 'ramda';
 
 import appConfig from '../App/configLoader';
 import userPresetsForDemo from './userPresetsForDemo';
@@ -69,8 +69,8 @@ class AppContextProvider extends Component {
 				showDateTimePopup: false,
 				showPopup: false,
 				showProfileEdit: false,
-				showUserSelectionPopup: false,
-				showWelcomePopup: 'defaultShowWelcomePopup' in props ? Boolean(props.defaultShowWelcomePopup) : true
+				showUserSelectionPopup: false
+				// showWelcomePopup: 'defaultShowWelcomePopup' in props ? Boolean(props.defaultShowWelcomePopup) : true
 			},
 			userId: 1,
 			userSettings: this.getDefaultUserSettings(1, props),
@@ -115,11 +115,11 @@ class AppContextProvider extends Component {
 	}
 
 	componentWillUpdate (nextProps, nextState) {
-		if (this.state.userId !== nextState.userId && this.state.userSettings === nextState.userSettings) {
+		if (this.state.userId !== nextState.userId && equals(this.state.userSettings, nextState.userSettings)) {
 			this.setUserSettings(nextState.userId);
 		}
 
-		if (this.state.userId === nextState.userId && this.state.userSettings !== nextState.userSettings) {
+		if (this.state.userId === nextState.userId && !equals(this.state.userSettings, nextState.userSettings)) {
 			if (nextState.userSettings !== this.state.userSettings) {
 				this.saveUserSettings(nextState.userId, nextState.userSettings);
 			}

--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -191,11 +191,11 @@ class MapCoreBase extends React.Component {
 	}
 
 	static defaultProps = {
+		// colorMarker: '#445566',
 		centeringDuration: 2000,
+		colorRouteLine: '#445566',
 		controlScheme: 'full',
 		viewLockoutDuration: 4000,
-		// colorMarker: '#445566',
-		colorRouteLine: '#445566',
 		zoomLevel: 12,
 		zoomToSpeedScaleFactor: 0.02
 	}
@@ -297,16 +297,9 @@ class MapCoreBase extends React.Component {
 
 	componentDidUpdate (prevProps) {
 		if (this.props.skin !== prevProps.skin) {
-			const style = skinStyles[prevProps.skin] || skinStyles.titanium;
+			const style = skinStyles[this.props.skin] || skinStyles.titanium;
 			this.map.setStyle(style);
 
-			// car and route layer needs to be added everytime the map reloaded when skin changes
-			addCarLayer({
-				coordinates: this.props.location,
-				iconURL: CarPng,
-				map: this.map,
-				orientation: this.props.location.orientation
-			});
 			// make sure the map is resized after the container updates
 			setTimeout(this.map.resize.bind(this.map), 0);
 		}

--- a/console/src/components/UserAvatar/UserAvatar.js
+++ b/console/src/components/UserAvatar/UserAvatar.js
@@ -1,5 +1,6 @@
 import GridListImageItem from '@enact/agate/GridListImageItem';
 import kind from '@enact/core/kind';
+import {adaptEvent, forward, handle} from '@enact/core/handle';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -30,9 +31,9 @@ const UserAvatarBase = kind({
 	},
 
 	handlers: {
-		onClick: (ev, {userId, onClick}) => {
-			onClick({selected: userId});
-		}
+		onClick: handle(
+			adaptEvent((ev, {userId}) => ({selected: userId}), forward('onClick'))
+		)
 	},
 
 	computed: {

--- a/console/src/components/UserSelectionPopup/UserSelectionPopup.js
+++ b/console/src/components/UserSelectionPopup/UserSelectionPopup.js
@@ -86,7 +86,7 @@ const UserSelectionPopupBase = kind({
 
 				<buttons>
 					<Button onClick={resetUserSettings}>Reset Current User</Button>
-					<Button onClick={onResetAll}>Start Demo</Button>
+					<Button onClick={onResetAll}>Restart Demo</Button>
 				</buttons>
 			</Popup>
 		);

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -1,9 +1,11 @@
 import Button from '@enact/agate/Button';
 import Divider from '@enact/agate/Divider';
 import FullscreenPopup from '@enact/agate/FullscreenPopup';
-import {Panel, Panels} from '@enact/agate/Panels';
+// import {Panel, Panels} from '@enact/agate/Panels';
+import {Panel} from '@enact/agate/Panels';
 import Skinnable from '@enact/agate/Skinnable';
-import {handle, forProp, forward, returnsTrue} from '@enact/core/handle';
+// import {handle, forProp, forward, returnsTrue} from '@enact/core/handle';
+import {handle, forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import {Column, Row, Cell} from '@enact/ui/Layout';
@@ -75,21 +77,21 @@ const WelcomePopupBase = kind({
 	propTypes: {
 		updateAppState: PropTypes.func.isRequired,
 		components: PropTypes.object,
-		index: PropTypes.number,
-		onCancelSelect: PropTypes.func,
+		// index: PropTypes.number,
+		// onCancelSelect: PropTypes.func,
 		onClose: PropTypes.func,
 		onContinue: PropTypes.func,
-		onSelectUser: PropTypes.func,
+		// onSelectUser: PropTypes.func,
 		onSendVideo: PropTypes.func,
-		onShowWelcome: PropTypes.func,
+		// onShowWelcome: PropTypes.func,
 		profileName: PropTypes.string,
-		updateUser: PropTypes.func,
+		// updateUser: PropTypes.func,
 		userId: PropTypes.number
 	},
 
-	defaultProps: {
-		index: 0
-	},
+	// defaultProps: {
+	// 	index: 0
+	// },
 
 	styles: {
 		css,
@@ -100,95 +102,95 @@ const WelcomePopupBase = kind({
 		handleClose: handle(
 			forward('onContinue'),
 			forward('onClose')
-		),
-		handleTransition: handle(
-			forProp('index', 1),
-			returnsTrue((ev, {selected, updateUser}) => updateUser({selected})),
-			forward('onShowWelcome')
-		)
+		)// ,
+		// handleTransition: handle(
+		// 	forProp('index', 1),
+		// 	returnsTrue((ev, {selected, updateUser}) => updateUser({selected})),
+		// 	forward('onShowWelcome')
+		// )
 	},
 
 	computed: {
-		className: ({index, styler}) => styler.append({
-			useWelcomeBackground: index < 2
-		}),
-		usersList: ({usersList}) => {
-			const users = [];
-			for (const user in usersList) {
-				users.push(usersList[user]);
-			}
-			return users;
-		},
+		// className: ({index, styler}) => styler.append({
+		// 	useWelcomeBackground: index < 2
+		// }),
+		// usersList: ({usersList}) => {
+		// 	const users = [];
+		// 	for (const user in usersList) {
+		// 		users.push(usersList[user]);
+		// 	}
+		// 	return users;
+		// },
 		small1Component: (props) => getCompactComponent({...props, key: 'small1'}),
 		small2Component: (props) => getCompactComponent({...props, key: 'small2'})
 	},
 
 	render: ({
 		handleClose,
-		handleTransition,
-		index,
-		onCancelSelect,
-		onSelectUser,
+		// handleTransition,
+		// index,
+		// onCancelSelect,
+		// onSelectUser,
 		profileName,
 		small1Component: Small1Component,
 		small2Component: Small2Component,
 		userId,
-		usersList,
+		// usersList,
 		...rest
 	}) => {
 		delete rest.components;
 		delete rest.onClose;
 		delete rest.onContinue;
 		delete rest.onSendVideo;
-		delete rest.onShowWelcome;
+		// delete rest.onShowWelcome;
 		delete rest.setDestination; // This needs to be assigned to somewhere. Most likely, this just needs to be toggling `navigating`, since the destination is set elsewhere.
 		delete rest.updateAppState;
-		delete rest.updateUser;
+		// delete rest.updateUser;
 
 		return (
 			<FullscreenPopup {...rest}>
-				<Panels arranger={Arranger} index={index} enteringProp="hideChildren" onTransition={handleTransition}>
-					<UserSelectionPanel users={usersList} onSelectUser={onSelectUser} />
-					<WelcomePanel />
-					<Panel>
-						<Row className={css.welcome}>
-							<Cell className={css.left} size="33%">
-								<Column>
-									<Cell shrink>
-										<Row>
-											<Cell className={css.avatar} shrink>
-												<UserAvatar css={css} userId={userId - 1} onClick={onCancelSelect} />
-											</Cell>
-											<Cell>
-												<Column align="start center">
-													<Cell shrink>Hi</Cell>
-													<Cell className={css.activeName} shrink>{profileName}!</Cell>
-												</Column>
-											</Cell>
-										</Row>
-									</Cell>
-									<Cell shrink>
-										{currentTime()}
-									</Cell>
-									<Cell className={css.smallComponent}>
-										{Small1Component}
-									</Cell>
-									<Cell className={css.smallComponent}>
-										{Small2Component}
-									</Cell>
-									<Cell component={Button} onClick={handleClose} shrink>{"Let's Go!"}</Cell>
-								</Column>
-							</Cell>
-							<Cell>
-								<MapController
-									noStartStopToggle
-									locationSelection
-									autonomousSelection
-								/>
-							</Cell>
-						</Row>
-					</Panel>
-				</Panels>
+				{/* <Panels arranger={Arranger} index={index} enteringProp="hideChildren" onTransition={handleTransition}> */}
+				{/* <UserSelectionPanel users={usersList} onSelectUser={onSelectUser} /> */}
+				{/* <WelcomePanel /> */}
+				<Panel>
+					<Row className={css.welcome}>
+						<Cell className={css.left} size="33%">
+							<Column>
+								<Cell shrink>
+									<Row>
+										<Cell className={css.avatar} shrink>
+											<UserAvatar css={css} userId={userId - 1} /* onClick={onCancelSelect} */ />
+										</Cell>
+										<Cell>
+											<Column align="start center">
+												<Cell shrink>Hi</Cell>
+												<Cell className={css.activeName} shrink>{profileName}!</Cell>
+											</Column>
+										</Cell>
+									</Row>
+								</Cell>
+								<Cell shrink>
+									{currentTime()}
+								</Cell>
+								<Cell className={css.smallComponent}>
+									{Small1Component}
+								</Cell>
+								<Cell className={css.smallComponent}>
+									{Small2Component}
+								</Cell>
+								<Cell component={Button} onClick={handleClose} shrink>{"Let's Go!"}</Cell>
+							</Column>
+						</Cell>
+						<Cell>
+							<MapController
+								noStartStopToggle
+								locationSelection
+								autonomousSelection
+							/>
+						</Cell>
+					</Row>
+				</Panel>
+				{/* </Panels> */}
 			</FullscreenPopup>
 		);
 	}
@@ -198,32 +200,32 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 	return class extends React.Component {
 		static displayName = 'WelcomePopupState';
 
-		static propTypes = {
-			open: PropTypes.bool,
-			skin: PropTypes.string
-		}
+		// static propTypes = {
+		// 	open: PropTypes.bool,
+		// 	skin: PropTypes.string
+		// }
 
-		constructor (props) {
-			super(props);
-			this.state = {
-				index: 0,
-				selected: null
-			};
-		}
+		// constructor (props) {
+		// 	super(props);
+		// 	this.state = {
+		// 		index: 0,
+		// 		selected: null
+		// 	};
+		// }
 
-		componentWillReceiveProps (nextProps) {
-			if (this.props.open && !nextProps.open) {
-				this.setState({index: 0});
-			}
-		}
+		// componentWillReceiveProps (nextProps) {
+		// 	if (this.props.open && !nextProps.open) {
+		// 		this.setState({index: 0});
+		// 	}
+		// }
 
-		handleSelectUser = ({selected}) => {
-			this.setState({index: 1, selected});
-		}
+		// handleSelectUser = ({selected}) => {
+		// 	this.setState({index: 1, selected});
+		// }
 
-		handleCancelSelect = () => {
-			this.setState({index: 0});
-		}
+		// handleCancelSelect = () => {
+		// 	this.setState({index: 0});
+		// }
 
 		handleContinue = () => {
 			this.props.updateAppState((state) => {
@@ -233,9 +235,9 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 			});
 		}
 
-		handleShowWelcome = () => {
-			this.setState(({index}) => index === 1 ? {index: ++index} : null);
-		}
+		// handleShowWelcome = () => {
+		// 	this.setState(({index}) => index === 1 ? {index: ++index} : null);
+		// }
 
 		setDestination = ({destination}) => {
 			this.props.updateAppState((state) => {
@@ -243,25 +245,25 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 			});
 		}
 
-		updateUser = ({selected}) => {
-			this.props.updateAppState((state) => {
-				state.userId = selected + 1;
-			});
-		}
+		// updateUser = ({selected}) => {
+		// 	this.props.updateAppState((state) => {
+		// 		state.userId = selected + 1;
+		// 	});
+		// }
 
 		render () {
-			const {index} = this.state;
+			// const {index} = this.state;
 
 			return (
 				<Wrapped
 					{...this.props}
-					index={index}
-					onSelectUser={this.handleSelectUser}
-					onCancelSelect={this.handleCancelSelect}
+					// index={index}
+					// onSelectUser={this.handleSelectUser}
+					// onCancelSelect={this.handleCancelSelect}
 					onContinue={this.handleContinue}
-					onShowWelcome={this.handleShowWelcome}
-					selected={this.state.selected}
-					updateUser={this.updateUser}
+					// onShowWelcome={this.handleShowWelcome}
+					// selected={this.state.selected}
+					// updateUser={this.updateUser}
 					setDestination={this.setDestination}
 				/>
 			);
@@ -269,12 +271,12 @@ const WelcomePopupState = hoc((configHoc, Wrapped) => {
 	};
 });
 
-const AppContextDecorator = AppContextConnect(({usersList, updateAppState, userId, userSettings}) => {
+const AppContextDecorator = AppContextConnect(({/* usersList, */updateAppState, userId, userSettings}) => {
 	return {
 		components: (userSettings.components && userSettings.components.welcome),
 		profileName: userSettings.name,
 		userId,
-		usersList: usersList,
+		// usersList: usersList,
 		updateAppState
 	};
 });

--- a/console/src/index.js
+++ b/console/src/index.js
@@ -26,7 +26,7 @@ if (typeof window !== 'undefined') {
 
 	appElement = (
 		<AppContextProvider
-			defaultShowWelcomePopup={args.showWelcomePopup !== 'false'}
+			// defaultShowWelcomePopup={args.showWelcomePopup !== 'false'}
 			defaultSkin={skin}
 		>
 			<App defaultIndex={index} onSelect={onSelect} />

--- a/console/src/index.js
+++ b/console/src/index.js
@@ -26,7 +26,7 @@ if (typeof window !== 'undefined') {
 
 	appElement = (
 		<AppContextProvider
-			// defaultShowWelcomePopup={args.showWelcomePopup !== 'false'}
+			defaultShowWelcomePopup={args.showWelcomePopup !== 'false'}
 			defaultSkin={skin}
 		>
 			<App defaultIndex={index} onSelect={onSelect} />


### PR DESCRIPTION
Commented out user selection popup related lines for a possible addition in the future.

`resetAll()` called in `UserSelectionPopup` is rewriting `userSettings` from local storage and the reference of the object will change. Changed it to deep compare the object to correctly reset settings.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>