### PR TITLE
PLAT-71500: Suppress map warnings

### DIFF
--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -538,6 +538,7 @@ class MapCoreBase extends React.Component {
 
 	drawDirection = async (waypoints) => {
 		// console.log('drawDirection:', waypoints);
+
 		this.setState({carShowing: true});
 		const data = await getRoute(waypoints);
 

--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -158,8 +158,14 @@ const addCarLayer = ({coordinates, iconURL, map, orientation = 0}) => {
 				}
 			};
 
-			map.addImage('car', icon);
-			map.addLayer(carLayer);
+			// If we remove the welcome screen while in the middle of an async call it throws an error.
+			// For now we can just supress it as a warning.
+			try {
+				map.addImage('car', icon);
+				map.addLayer(carLayer);
+			} catch(err) {
+				console.warn('Map is unmounted.', error);
+			}
 		});
 	}
 };
@@ -532,7 +538,6 @@ class MapCoreBase extends React.Component {
 
 	drawDirection = async (waypoints) => {
 		// console.log('drawDirection:', waypoints);
-
 		this.setState({carShowing: true});
 		const data = await getRoute(waypoints);
 
@@ -569,7 +574,16 @@ class MapCoreBase extends React.Component {
 			// this.setState(travelInfo);
 
 			// const routeLayer = this.map.getLayer('route');
-			const direction = this.map.getSource('route');
+
+			// If we remove the welcome screen while in the middle of an async call it throws an error.
+			// For now we can just supress it as a warning.
+			let direction = null;
+			try {
+				direction = this.map.getSource('route');
+			} catch (error) {
+				console.warn('Map is unmounted', error);
+				return;
+			}
 			if (direction) {
 				// if (direction) debugger;
 				direction.setData({


### PR DESCRIPTION
Every once in a while if we move from the map too quickly while we're in the middle of an async function it errors out. 

The proper way would be to figure out how to do cancellable promises and cancel the promise before it returns, but just using try..catch is enough to go around the error for now.

This should not be a problem when we pack the application for production, but incase we need to sideload anything in the worst case we won't have any show stopping error pages.