### PR TITLE
PLAT-71040 - Fine tune the preset destinations so that we stop in a good spot

### DIFF
--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -79,8 +79,8 @@ class AppContextProvider extends Component {
 				serviceLayer: false
 			},
 			location: {
-				lat: 0,
-				lon: 0,
+				lat: 37.78878,
+				lon: -122.40467,
 				linearVelocity: 0,
 				orientation: 0
 			},

--- a/console/src/App/userPresetsForDemo.json
+++ b/console/src/App/userPresetsForDemo.json
@@ -32,23 +32,23 @@
 		"topLocations": [
 			{
 					"description": "Home",
-					"coordinates": {"lat": 37.790246, "lon": -122.396601}
+					"coordinates": {"lat": 37.790416, "lon": -122.396185}
 			},
 			{
 					"description": "Philz coffee",
-					"coordinates": {"lat": 37.789026, "lon": -122.392775}
+					"coordinates": {"lat": 37.788920, "lon": -122.393154}
 			},
 			{
 					"description": "School",
-					"coordinates": {"lat": 37.79395, "lon": -122.40185}
+					"coordinates": {"lat": 37.793424, "lon": -122.401124}
 			},
 			{
 					"description": "Work",
-					"coordinates": {"lat": 37.78353, "lon": -122.39615}
+					"coordinates": {"lat": 37.783902, "lon": -122.396148}
 			},
 			{
 					"description": "MOMA",
-					"coordinates": {"lat": 37.786445, "lon": -122.404202}
+					"coordinates": {"lat": 37.785684, "lon": -122.401035}
 			}
 		]
 	},
@@ -108,23 +108,23 @@
 		"topLocations": [
 			{
 					"description": "Home",
-					"coordinates": {"lat": 37.790246, "lon": -122.396601}
+					"coordinates": {"lat": 37.790416, "lon": -122.396185}
 			},
 			{
 					"description": "Philz coffee",
-					"coordinates": {"lat": 37.789026, "lon": -122.392775}
+					"coordinates": {"lat": 37.788920, "lon": -122.393154}
 			},
 			{
 					"description": "School",
-					"coordinates": {"lat": 37.79395, "lon": -122.40185}
+					"coordinates": {"lat": 37.793318, "lon": -122.400845}
 			},
 			{
 					"description": "Work",
-					"coordinates": {"lat": 37.78353, "lon": -122.39615}
+					"coordinates": {"lat": 37.783902, "lon": -122.396148}
 			},
 			{
 					"description": "MOMA",
-					"coordinates": {"lat": 37.786445, "lon": -122.404202}
+					"coordinates": {"lat": 37.785684, "lon": -122.401035}
 			}
 		]
 	}


### PR DESCRIPTION
Took some time with the simulator. This isn't perfect, but I think it's better than where we started. I mostly made everything stop on the right side. I think right turns are a bit easier for the simulator. I'm also not stopping on any corners. I also picked spots that are close to sidewalks instead of stores that are more inside which look like they confuse the simulator.