### PR TITLE
PLAT-71569: Add expand button to MapController

### DIFF
--- a/console/src/components/CompactMap/CompactMap.js
+++ b/console/src/components/CompactMap/CompactMap.js
@@ -20,13 +20,14 @@ const CompactMapBase = kind({
 		className: 'compactMap'
 	},
 
-	render: ({follow, ...rest}) => {
+	render: ({follow, onExpand, ...rest}) => {
 		return (
 			<Widget {...rest} title="Map" description="Choose a destination and navigate" noHeader>
 				<small>
 					<MapController
 						controlScheme="compact"
 						follow={follow}
+						onExpand={onExpand}
 					/>
 				</small>
 				<large>
@@ -35,6 +36,7 @@ const CompactMapBase = kind({
 						locationSelection
 						autonomousSelection
 						follow={follow}
+						onExpand={onExpand}
 					>
 						{/* <tools>
 							<Button alt="Fullscreen" icon="fullscreen" data-tabindex={getPanelIndexOf('map')} onSelect={onSelect} onKeyUp={onTabChange} onClick={onTabChange} />

--- a/console/src/components/MapController/MapController.js
+++ b/console/src/components/MapController/MapController.js
@@ -7,6 +7,7 @@ import Group from '@enact/ui/Group';
 import {Cell, Column, Row} from '@enact/ui/Layout';
 import Button from '@enact/agate/Button';
 import Divider from '@enact/agate/Divider';
+import IconButton from '@enact/agate/IconButton';
 import ToggleButton from '@enact/agate/ToggleButton';
 
 import AppContextConnect from '../../App/AppContextConnect';
@@ -108,25 +109,33 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 			});
 		}
 
+		onExpand = () => {
+			if (this.props.onExpand) {
+				this.props.onExpand({view: 'map'});
+			}
+		}
+
 		render () {
 			const {
+				autonomousSelection,
 				destination,
 				locationSelection,
 				navigating,
 				navigation,
+				noExpandButton,
 				noStartStopToggle,
-				autonomousSelection,
 				topLocations,
 				...rest
 			} = this.props;
 
 			delete rest.centeringDuration;
 			delete rest.defaultFollow;
+			delete rest.onExpand;
 			delete rest.position;
+			delete rest.updateAppState;
 			delete rest.updateProposedDestination;
 			delete rest.viewLockoutDuration;
 			delete rest.zoomToSpeedScaleFactor;
-			delete rest.updateAppState;
 			const durationIncrements = ['day', 'hour', 'min'];
 
 			return (
@@ -140,6 +149,19 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 				>
 					<tools>
 						<Column className={css.toolsColumn}>
+							{
+								noExpandButton ?
+									null :
+									(<Cell align="end" shrink>
+										<IconButton
+											size="smallest"
+											alt="Fullscreen"
+											onClick={this.onExpand}
+										>
+											expand
+										</IconButton>
+									</Cell>)
+							}
 							{
 								autonomousSelection &&
 								<Cell shrink={locationSelection} className={css.columnCell}>

--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -253,13 +253,6 @@ class MapCoreBase extends React.Component {
 			zoom: this.zoomLevel
 		});
 
-		this.map.addControl(new mapboxgl.GeolocateControl({
-			positionOptions: {
-				enableHighAccuracy: true
-			},
-			trackUserLocation: true
-		}));
-
 		this.map.on('load', () => {
 			this.map.addLayer(markerLayer);
 			addCarLayer({

--- a/console/src/components/MapCore/MapCore.less
+++ b/console/src/components/MapCore/MapCore.less
@@ -20,7 +20,7 @@
 		position: absolute;
 		.position(0, 0, 0, auto);
 		z-index: 10;
-		padding: @agate-app-keepout;
+		padding: @agate-app-keepout * 2;
 
 		.button {
 			margin: 9px 0;

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -185,6 +185,7 @@ const WelcomePopupBase = kind({
 								noStartStopToggle
 								locationSelection
 								autonomousSelection
+								noExpandButton
 							/>
 						</Cell>
 					</Row>

--- a/console/src/views/Map.js
+++ b/console/src/views/Map.js
@@ -18,7 +18,7 @@ const MapViewBase = kind({
 	render: ({...rest}) => {
 		return (
 			<Panel {...rest}>
-				<MapController autonomousSelection locationSelection>
+				<MapController autonomousSelection locationSelection noExpandButton>
 					{/* <tools>
 						<Button alt="POI search" icon="search" />
 						<Button alt="Propose new destination" icon="arrowhookleft" onClick={changePosition} />


### PR DESCRIPTION
Remove [GeoLocation controls](https://www.mapbox.com/mapbox-gl-js/api/#geolocatecontrol) from map box.
Add expand icon button to `MapController` to make transitioning to Navigation app available.

Instead of using the `CompactHeader`'s pre-existing expand button, decided to incorporate inside the `MapController` as fixing the layout clash with the tools and the header requires more code changes to the `MapController`.

And minor padding update to respect the overall grid.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>