### PR TITLE
PLAT-71043: Added "You've Arrived" Popup and related logic

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -83,6 +83,11 @@ const AppBase = kind({
 				state.appState.showDateTimePopup = !state.appState.showDateTimePopup;
 			});
 		},
+		onToggleDestinationReachedPopup: (ev, {updateAppState}) => {
+			updateAppState((state) => {
+				state.appState.showDestinationReachedPopup = !state.appState.showDestinationReachedPopup;
+			});
+		},
 		onToggleWelcomePopup: (ev, {updateAppState}) => {
 			updateAppState((state) => {
 				state.appState.showWelcomePopup = !state.appState.showWelcomePopup;
@@ -102,9 +107,10 @@ const AppBase = kind({
 			onSelect({index: 0});
 			updateAppState((state) => {
 				state.userId = 1;
-				state.appState.showWelcomePopup = true;
-				state.appState.showUserSelectionPopup = false;
+				state.appState.showDestinationReachedPopup = false;
 				state.appState.showProfileEdit = false;
+				state.appState.showUserSelectionPopup = false;
+				state.appState.showWelcomePopup = true;
 			});
 		}
 	},
@@ -116,6 +122,7 @@ const AppBase = kind({
 		onSelect,
 		onToggleBasicPopup,
 		onToggleDateTimePopup,
+		onToggleDestinationReachedPopup,
 		onTogglePopup,
 		onToggleProfileEdit,
 		onToggleWelcomePopup,
@@ -125,6 +132,7 @@ const AppBase = kind({
 		sendVideo,
 		showBasicPopup,
 		showDateTimePopup,
+		showDestinationReachedPopup,
 		showPopup,
 		showUserSelectionPopup,
 		showWelcomePopup,
@@ -213,6 +221,12 @@ const AppBase = kind({
 					{`Popup for ${skinName} skin`}
 				</Popup>
 				<Popup
+					onClose={onToggleDestinationReachedPopup}
+					open={showDestinationReachedPopup}
+				>
+					Destination reached!
+				</Popup>
+				<Popup
 					onClose={onTogglePopup}
 					open={showPopup}
 					closeButton
@@ -289,6 +303,7 @@ const AppDecorator = compose(
 		showAppList: appState.showAppList,
 		showBasicPopup: appState.showBasicPopup,
 		showDateTimePopup: appState.showDateTimePopup,
+		showDestinationReachedPopup: appState.showDestinationReachedPopup,
 		showPopup: appState.showPopup,
 		showUserSelectionPopup: appState.showUserSelectionPopup,
 		showWelcomePopup: appState.showWelcomePopup,

--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -67,6 +67,7 @@ class AppContextProvider extends Component {
 				showAppList: false,
 				showBasicPopup: false,
 				showDateTimePopup: false,
+				showDestinationReachedPopup: false,
 				showPopup: false,
 				showProfileEdit: false,
 				showUserSelectionPopup: false,


### PR DESCRIPTION
### Added "You've Arrived" Popup and related logic

You can use the new `this.generateFakeLocations();` method to test/verify/tinker if you add and navigate to a destination on that route. I used the following destination added to the user's `topLocations`:
```
{
	"description": "Ferry Building",
	"coordinates": {"lat": 37.792977, "lon": -122.396701}
}
```

The Popup only appears once per choosen destination, appears when you're 50 meters away and traveling at less than 1 meter per second (~2.2MPH), so you're essentially slowing down to an eventual stop at your destination. Choosing a different destination, or removing your current destination, resets the ability for the popup to appear again. The popup intentionally doesn't disappear automatically, requiring user acknowledgement.