### PR TITLE
PLAT-71499: "follow" mode has been restored, addressing zoom

### DIFF
--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -92,7 +92,7 @@ class AppContextProvider extends Component {
 				distance: 0,
 				duration: 0,
 				eta: 0,
-				follow: false,
+				follow: true,
 				navigating: false,
 				startTime: 0
 			},

--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -92,6 +92,7 @@ class AppContextProvider extends Component {
 				distance: 0,
 				duration: 0,
 				eta: 0,
+				follow: false,
 				navigating: false,
 				startTime: 0
 			},

--- a/console/src/components/MapController/MapController.js
+++ b/console/src/components/MapController/MapController.js
@@ -43,7 +43,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 
 		static defaultProps = {
 			centeringDuration: 2000,
-			follow: false,
+			follow: true,
 			viewLockoutDuration: 4000,
 			zoomToSpeedScaleFactor: 0.02
 		}

--- a/console/src/components/MapController/MapController.js
+++ b/console/src/components/MapController/MapController.js
@@ -129,6 +129,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 				navigating,
 				navigation,
 				noExpandButton,
+				noFollowButton,
 				noStartStopToggle,
 				topLocations,
 				...rest
@@ -156,24 +157,29 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 					<tools>
 						<Column className={css.toolsColumn}>
 							<Cell align="end" shrink>
-								<IconButton
-									size="smallest"
-									alt="Follow Mode"
-									selected={follow}
-									onClick={this.toggleFollow}
-								>
-										exitfullscreen
-								</IconButton>
-								{noExpandButton ?
-									null : (
+								{
+									noFollowButton ?
+										null :
+										<IconButton
+											size="smallest"
+											alt="Follow Mode"
+											selected={follow}
+											onClick={this.toggleFollow}
+										>
+											exitfullscreen
+										</IconButton>
+								}
+								{
+									noExpandButton ?
+										null :
 										<IconButton
 											size="smallest"
 											alt="Fullscreen"
 											onClick={this.onExpand}
 										>
-										expand
+											expand
 										</IconButton>
-									)}
+								}
 							</Cell>
 							{
 								autonomousSelection &&

--- a/console/src/components/MapController/MapController.js
+++ b/console/src/components/MapController/MapController.js
@@ -28,9 +28,9 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 			autonomousSelection: PropTypes.bool,
 			centeringDuration: PropTypes.number,
 			compact: PropTypes.bool,
-			defaultFollow: PropTypes.bool, // Should the centering position follow the current location?
 			description: PropTypes.string,
 			destination: propTypeLatLonList,
+			follow: PropTypes.bool,
 			locationSelection: PropTypes.bool,
 			navigating: PropTypes.bool,
 			navigation: PropTypes.object,
@@ -43,6 +43,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 
 		static defaultProps = {
 			centeringDuration: 2000,
+			follow: false,
 			viewLockoutDuration: 4000,
 			zoomToSpeedScaleFactor: 0.02
 		}
@@ -52,7 +53,6 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 
 			this.state = {
 				carShowing: true,
-				follow: props.defaultFollow || false,
 				selfDriving: true
 			};
 		}
@@ -84,6 +84,11 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 		toggleAutonomous = () => {
 			this.props.updateAppState((state) => {
 				state.navigation.autonomous = !state.navigation.autonomous;
+			});
+		}
+		toggleFollow = () => {
+			this.props.updateAppState((state) => {
+				state.navigation.follow = !state.navigation.follow;
 			});
 		}
 		updateDestination = ({description, destination, navigating = false}) => {
@@ -119,6 +124,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 			const {
 				autonomousSelection,
 				destination,
+				follow,
 				locationSelection,
 				navigating,
 				navigation,
@@ -129,7 +135,6 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 			} = this.props;
 
 			delete rest.centeringDuration;
-			delete rest.defaultFollow;
 			delete rest.onExpand;
 			delete rest.position;
 			delete rest.updateAppState;
@@ -142,6 +147,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 				<Wrapped
 					{...rest}
 					// className={classnames(className, css.map)}
+					follow={follow}
 					destination={destination}
 					points={topLocations}
 					updateDestination={this.updateDestination}
@@ -149,19 +155,26 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 				>
 					<tools>
 						<Column className={css.toolsColumn}>
-							{
-								noExpandButton ?
-									null :
-									(<Cell align="end" shrink>
+							<Cell align="end" shrink>
+								<IconButton
+									size="smallest"
+									alt="Follow Mode"
+									selected={follow}
+									onClick={this.toggleFollow}
+								>
+										exitfullscreen
+								</IconButton>
+								{noExpandButton ?
+									null : (
 										<IconButton
 											size="smallest"
 											alt="Fullscreen"
 											onClick={this.onExpand}
 										>
-											expand
+										expand
 										</IconButton>
-									</Cell>)
-							}
+									)}
+							</Cell>
 							{
 								autonomousSelection &&
 								<Cell shrink={locationSelection} className={css.columnCell}>
@@ -235,6 +248,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 
 
 const ConnectedMap = AppContextConnect(({location, userSettings, navigation, updateAppState}) => ({
+	follow: navigation.follow,
 	topLocations: userSettings.topLocations,
 	location,
 	navigation,

--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -42,6 +42,8 @@ const getBoundsOfAll = (waypoints, existingBounds) => {
 	);
 };
 
+const clampZoom = (zoom) => Math.min(20, Math.max(0, zoom));
+
 const getMapPadding = () => {
 	const edgeClearance = 48;
 	return {
@@ -186,8 +188,8 @@ class MapCoreBase extends React.Component {
 		// colorMarker: PropTypes.string,
 		colorRouteLine: PropTypes.string,
 		controlScheme: PropTypes.oneOf(['compact', 'full']), // 'compact' or 'full' (default is full)
-		defaultFollow: PropTypes.bool, // Should the centering position follow the current location?
 		destination: propTypeLatLonList,
+		follow: PropTypes.bool, // Should the centering position follow the current location?
 		location: propTypeLatLon, // Our actual current location on the world
 		points: PropTypes.array,
 		position: propTypeLatLon, // The map's centering position
@@ -207,7 +209,7 @@ class MapCoreBase extends React.Component {
 		points: [],
 		routeRedrawInterval: 3000,
 		viewLockoutDuration: 4000,
-		zoomLevel: 12,
+		zoomLevel: 15,
 		zoomToSpeedScaleFactor: 0.02
 	}
 
@@ -221,7 +223,6 @@ class MapCoreBase extends React.Component {
 
 		this.state = {
 			carShowing: true,
-			follow: props.defaultFollow || false,
 			selfDriving: true
 		};
 	}
@@ -326,7 +327,10 @@ class MapCoreBase extends React.Component {
 		if (this.props.location && (!prevProps.location ||
 			prevProps.location.linearVelocity !== this.props.location.linearVelocity
 		)) {
-			actions.zoom = this.props.location.linearVelocity;
+			if (this.props.follow) {
+				actions.zoom = this.props.location.linearVelocity;
+				actions.center = this.props.location;
+			}
 		}
 
 		// Received a new location
@@ -378,17 +382,15 @@ class MapCoreBase extends React.Component {
 						break;
 					}
 					case 'positionCar': {
-						window.requestAnimationFrame(() => this.updateCarLayer({location: actions[action]}));
+						// window.requestAnimationFrame(() => this.updateCarLayer({location: actions[action]}));
+						this.updateCarLayer({location: actions[action]});
 						break;
 					}
 					case 'center': {
-						this.centerMap({center: actions[action]});
+						this.centerMap({center: actions[action], duration: 450});
 						break;
 					}
 					case 'zoom': {
-						// if following
-						// if (this.props.follow) {
-
 						this.velocityZoom(actions[action]);
 						break;
 					}
@@ -426,12 +428,13 @@ class MapCoreBase extends React.Component {
 	}
 
 	velocityZoom = (linearVelocity) => {
-		const zoom = this.state.follow ? this.calculateZoomLevel(linearVelocity) : this.zoomLevel;
-		this.zoomMap(zoom);
+		const zoom = this.props.follow ? this.calculateZoomLevel(linearVelocity) : this.zoomLevel;
+		// this.zoomMap(zoom);
+		this.zoomLevel = clampZoom(zoom);
 	}
 
 	zoomMap = (zoomLevel) => {
-		zoomLevel = Math.min(20, Math.max(0, zoomLevel));
+		zoomLevel = clampZoom(zoomLevel);
 		this.zoomLevel = zoomLevel;
 		if (!this.viewLockTimer) {
 			console.log('zoomTo:', zoomLevel);
@@ -447,28 +450,28 @@ class MapCoreBase extends React.Component {
 		this.zoomMap(this.zoomLevel - 1);
 	}
 
-	centerMap = ({center = this.props.location, instant = false}) => {
+	centerMap = ({center = this.props.location, instant = false, duration}) => {
 		// Never center the map if we're currently in view-lock
 		if (!this.viewLockTimer) {
 			center = (center instanceof Array) ? center : toMapbox(center);
 
 			if (instant) {
+				// console.log('jumpTo to:', center[0], center[1]);
 				this.map.jumpTo({center});
 			} else {
-				// console.log('centerMap to:', center[0], center[1], center);
-				this.map.panTo(
-					center,
-					{duration: 800, easing: linear, animation: true}
-				);
-				// this.map.flyTo(
-				// 	{
-				// 		center,
-				// 		// maxDuration: this.props.centeringDuration,
-				// 		zoom
-				// 	},
-				// 	// {duration: (instant ? 500 : 500)}
-				// 	{duration: 800, easing: linear, animation: true}
+				// console.log('panTo to:', center[0], center[1]);
+				// this.map.panTo(
+				// 	center,
+				// 	{duration: duration || 800, easing: linear, animation: true}
 				// );
+				this.map.flyTo(
+					{
+						center,
+						maxDuration: this.props.centeringDuration,
+						zoom: this.zoomLevel
+					},
+					{duration: duration || 800, easing: linear, animation: true}
+				);
 			}
 			// this.map.flyTo({center, maxDuration: (instant ? 500 : this.props.centeringDuration)});
 			this.localinfo.center = toLatLon(this.map.getCenter()); // save the current center, based on their truth rather than ours
@@ -643,12 +646,6 @@ class MapCoreBase extends React.Component {
 	// 	// this.props.updateDestination(this.points[selected]);
 	// }
 
-	changeFollow = () => {
-		this.setState(({follow}) => ({
-			follow: !follow
-		}));
-	}
-
 	setContextRef = () => {
 		this.context.getMap(this);
 	}
@@ -666,8 +663,8 @@ class MapCoreBase extends React.Component {
 		delete rest.centeringDuration;
 		// delete rest.colorMarker;
 		delete rest.colorRouteLine;
-		delete rest.defaultFollow;
 		delete rest.destination;
+		delete rest.follow;
 		delete rest.location;
 		delete rest.points;
 		delete rest.position;

--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -335,7 +335,8 @@ class MapCoreBase extends React.Component {
 
 		// Received a new location
 		if (!equals(prevProps.location, this.props.location)) {
-			actions.center = this.props.location;
+			// only center during following mode
+			// actions.center = this.props.location;
 			actions.positionCar = this.props.location;
 
 			if (this.props.destination && this.props.destination.length > 0) {

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -186,6 +186,7 @@ const WelcomePopupBase = kind({
 								locationSelection
 								autonomousSelection
 								noExpandButton
+								noFollowButton
 							/>
 						</Cell>
 					</Row>

--- a/console/src/data/ServiceLayer.js
+++ b/console/src/data/ServiceLayer.js
@@ -31,6 +31,7 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 			updateDestination: PropTypes.func.isRequired,
 			autonomous: PropTypes.bool,
 			destination: propTypeLatLonList,
+			follow: PropTypes.bool,
 			location: propTypeLatLon,
 			navigating: PropTypes.bool,
 			navigation: PropTypes.object
@@ -204,14 +205,17 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 				this.isFirstPosition = false;
 			}
 
-			// If the location is more than 0.5 meters apart, go ahead and update the location.
-			if (this.maps.size > 0 && metersFromLastLocation > 0.5) {
+			// If the location is more than 0.01 meters apart, go ahead and update the location.
+			if (this.maps.size > 0 && metersFromLastLocation > 0.01) {
 				for (let map of this.maps) {
 					if (map.actionManager) {
-						map.actionManager({
-							positionCar: location,
-							center: location
-						});
+						const actions = {
+							positionCar: location
+						};
+						if (this.props.follow) {
+							actions.center = location;
+						}
+						map.actionManager(actions);
 					}
 				}
 			}
@@ -330,6 +334,7 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 		render () {
 			const {...rest} = this.props;
 			delete rest.autonomous;
+			delete rest.follow;
 			delete rest.location;
 			delete rest.navigating;
 			delete rest.navigation;
@@ -359,6 +364,7 @@ const ServiceLayer = compose(
 	AppStateConnect(({location: locationProp, navigation, updateAppState}) => ({
 		autonomous: navigation.autonomous,
 		destination: navigation.destination,
+		follow: navigation.follow,
 		location: locationProp,
 		navigation,
 		navigating: navigation.navigating,


### PR DESCRIPTION
Follow mode is now back and available as a toggleable UI button.
The rAF was causing the actionManager method to only ever fire one action, since most of the actions require more than 16ms to complete, so it was removed (commented).
Converted centerMap back to `flyTo` method so it can handle zooming as well, and velocityZoom just assigns the zoomLevel, rather than invoking a change.
Default zoom level changed to 15 from 12. We don't need to see all of SF, just our area.

Depends on changes from #163 (I think), merge after #163.