### PR TITLE
PLAT-71496: Create a widget to display the rear seat video stream

### DIFF
--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -64,6 +64,7 @@ class AppContextProvider extends Component {
 		this.watchPositionId = null;  // Store the reference to the position watcher.
 		this.state = {
 			appState:{
+				nowPlaying: [],
 				showAppList: false,
 				showBasicPopup: false,
 				showDateTimePopup: false,

--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -64,7 +64,6 @@ class AppContextProvider extends Component {
 		this.watchPositionId = null;  // Store the reference to the position watcher.
 		this.state = {
 			appState:{
-				nowPlaying: [],
 				showAppList: false,
 				showBasicPopup: false,
 				showDateTimePopup: false,
@@ -85,6 +84,9 @@ class AppContextProvider extends Component {
 				lon: -122.40467,
 				linearVelocity: 0,
 				orientation: 0
+			},
+			multimedia: {
+				nowPlaying: []
 			},
 			navigation: {
 				autonomous: true,

--- a/console/src/components/CompactMultimedia/CompactMultimedia.js
+++ b/console/src/components/CompactMultimedia/CompactMultimedia.js
@@ -1,13 +1,67 @@
+import Cell from '@enact/ui/Layout';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import {WidgetBase, WidgetDecorator} from '../Widget';
 
+import AppStateConnect from '../../App/AppContextConnect';
 import {ScreenSelectionPopup} from '../../../../components/ScreenSelectionPopup';
 import {MultimediaDecorator, ResponsiveVirtualList} from '../../views/Multimedia';
 
 import css from './CompactMultimedia.less';
+
+const CompactScreenMonitorBase = kind({
+	name: 'CompactScreenMonitor',
+	propTypes: {
+		containerShape: PropTypes.object,
+		screenId: PropTypes.number,
+		screenImage: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+	},
+	styles: {
+		css,
+		className: 'compactScreenMonitor'
+	},
+	computed: {
+		className: ({containerShape: {size: {relative = 'small'}}, styler}) => {
+			return styler.append(relative && css[relative]);
+		},
+		imgUrl: ({containerShape: {size: {relative = 'small'}}, nowPlaying}) => {
+			if (!nowPlaying[1]) return;
+			if (relative === 'small') {
+				return nowPlaying[1].medium.url;
+			}
+			return nowPlaying[1].high.url;
+		},
+		videoUrl: ({nowPlaying}) => {
+			if (!nowPlaying[1]) return;
+			const parts = nowPlaying[1].default.url.split('/');
+			parts.pop();
+			const videoId = parts.pop();
+			return `https://www.youtube.com/embed/${videoId}`;
+		}
+	},
+	render: ({imgUrl, videoUrl, ...rest}) => {
+		delete rest.nowPlaying;
+
+		return (
+			<WidgetBase
+				{...rest}
+				align="flex-start space-between"
+				title="Now Playing"
+				view="multimedia"
+			>
+				<video src={videoUrl} poster={imgUrl} />
+				<Cell />
+			</WidgetBase>
+		);
+	}
+});
+
+const CompactScreenMonitor = AppStateConnect(({appState: {nowPlaying}}) => ({
+		nowPlaying
+	})
+)(WidgetDecorator(CompactScreenMonitorBase));
 
 const CompactMultimediaBase = kind({
 	name: 'CompactMultimedia',
@@ -77,5 +131,6 @@ const CompactMultimedia = MultimediaDecorator(
 
 export default CompactMultimedia;
 export {
-	CompactMultimedia
+	CompactMultimedia,
+	CompactScreenMonitor
 };

--- a/console/src/components/CompactMultimedia/CompactMultimedia.js
+++ b/console/src/components/CompactMultimedia/CompactMultimedia.js
@@ -1,67 +1,12 @@
-import Cell from '@enact/ui/Layout';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import {WidgetBase, WidgetDecorator} from '../Widget';
-
-import AppStateConnect from '../../App/AppContextConnect';
 import {ScreenSelectionPopup} from '../../../../components/ScreenSelectionPopup';
 import {MultimediaDecorator, ResponsiveVirtualList} from '../../views/Multimedia';
 
 import css from './CompactMultimedia.less';
-
-const CompactScreenMonitorBase = kind({
-	name: 'CompactScreenMonitor',
-	propTypes: {
-		containerShape: PropTypes.object,
-		screenId: PropTypes.number,
-		screenImage: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
-	},
-	styles: {
-		css,
-		className: 'compactScreenMonitor'
-	},
-	computed: {
-		className: ({containerShape: {size: {relative = 'small'}}, styler}) => {
-			return styler.append(relative && css[relative]);
-		},
-		imgUrl: ({containerShape: {size: {relative = 'small'}}, nowPlaying}) => {
-			if (!nowPlaying[1]) return;
-			if (relative === 'small') {
-				return nowPlaying[1].medium.url;
-			}
-			return nowPlaying[1].high.url;
-		},
-		videoUrl: ({nowPlaying}) => {
-			if (!nowPlaying[1]) return;
-			const parts = nowPlaying[1].default.url.split('/');
-			parts.pop();
-			const videoId = parts.pop();
-			return `https://www.youtube.com/embed/${videoId}`;
-		}
-	},
-	render: ({imgUrl, videoUrl, ...rest}) => {
-		delete rest.nowPlaying;
-
-		return (
-			<WidgetBase
-				{...rest}
-				align="flex-start space-between"
-				title="Now Playing"
-				view="multimedia"
-			>
-				<video src={videoUrl} poster={imgUrl} />
-				<Cell />
-			</WidgetBase>
-		);
-	}
-});
-
-const CompactScreenMonitor = AppStateConnect(({appState: {nowPlaying}}) => ({
-		nowPlaying
-	})
-)(WidgetDecorator(CompactScreenMonitorBase));
 
 const CompactMultimediaBase = kind({
 	name: 'CompactMultimedia',
@@ -131,6 +76,5 @@ const CompactMultimedia = MultimediaDecorator(
 
 export default CompactMultimedia;
 export {
-	CompactMultimedia,
-	CompactScreenMonitor
+	CompactMultimedia
 };

--- a/console/src/components/CompactMultimedia/CompactMultimedia.less
+++ b/console/src/components/CompactMultimedia/CompactMultimedia.less
@@ -23,3 +23,9 @@
 		}
 	}
 }
+
+.compactScreenMonitor {
+	video {
+		width: 100%;
+	}
+}

--- a/console/src/components/CompactScreenMonitor/CompactScreenMonitor.js
+++ b/console/src/components/CompactScreenMonitor/CompactScreenMonitor.js
@@ -1,0 +1,72 @@
+import {Cell} from '@enact/ui/Layout';
+import kind from '@enact/core/kind';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {WidgetBase, WidgetDecorator} from '../Widget';
+import AppStateConnect from '../../App/AppContextConnect';
+
+import css from './CompactScreenMonitor.less';
+
+const CompactScreenMonitorBase = kind({
+	name: 'CompactScreenMonitor',
+	propTypes: {
+		nowPlaying: PropTypes.array.isRequired,
+		containerShape: PropTypes.object,
+		screenId: PropTypes.number,
+		screenImage: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+	},
+	defaultProps: {
+		screenId: 1
+	},
+	styles: {
+		css,
+		className: 'compactScreenMonitor'
+	},
+	computed: {
+		className: ({containerShape: {size: {relative = 'small'}}, styler}) => {
+			return styler.append(relative && css[relative]);
+		},
+		imgUrl: ({containerShape: {size: {relative = 'small'}}, nowPlaying, screenId}) => {
+			if (!nowPlaying[screenId]) return;
+			if (relative === 'small') {
+				return nowPlaying[screenId].medium.url;
+			}
+			return nowPlaying[screenId].high.url;
+		},
+		videoUrl: ({nowPlaying, screenId}) => {
+			if (!nowPlaying[screenId]) return;
+			const parts = nowPlaying[screenId].default.url.split('/');
+			parts.pop();
+			const videoId = parts.pop();
+			return `https://www.youtube.com/embed/${videoId}`;
+		}
+	},
+	render: ({imgUrl, videoUrl, ...rest}) => {
+		delete rest.nowPlaying;
+		delete rest.containerShape;
+		delete rest.screenId;
+		delete rest.screenImage;
+
+		return (
+			<WidgetBase
+				{...rest}
+				title="Now Playing"
+				view="multimedia"
+			>
+				<Cell component="video" src={videoUrl} poster={imgUrl} />
+			</WidgetBase>
+		);
+	}
+});
+
+const CompactScreenMonitor = AppStateConnect(
+	({multimedia}) => ({
+		nowPlaying: multimedia.nowPlaying
+	})
+)(WidgetDecorator(CompactScreenMonitorBase));
+
+export default CompactScreenMonitor;
+export {
+	CompactScreenMonitor
+};

--- a/console/src/components/CompactScreenMonitor/CompactScreenMonitor.less
+++ b/console/src/components/CompactScreenMonitor/CompactScreenMonitor.less
@@ -1,0 +1,5 @@
+.compactScreenMonitor {
+	video {
+		width: 100%;
+	}
+}

--- a/console/src/components/CompactScreenMonitor/package.json
+++ b/console/src/components/CompactScreenMonitor/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "CompactScreenMonitor.js"
+}

--- a/console/src/data/ServiceLayer.js
+++ b/console/src/data/ServiceLayer.js
@@ -273,6 +273,10 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 		}
 
 		sendVideo = (args) => {
+			const {screenId, video: {snippet: {thumbnails}}} = args;
+			this.props.updateAppState((state) => {
+				state.appState.nowPlaying[screenId] = thumbnails;
+			});
 			this.comm.current.sendVideo(args);
 		}
 

--- a/console/src/data/ServiceLayer.js
+++ b/console/src/data/ServiceLayer.js
@@ -275,7 +275,7 @@ const ServiceLayerBase = hoc((configHoc, Wrapped) => {
 		sendVideo = (args) => {
 			const {screenId, video: {snippet: {thumbnails}}} = args;
 			this.props.updateAppState((state) => {
-				state.appState.nowPlaying[screenId] = thumbnails;
+				state.multimedia.nowPlaying[screenId] = thumbnails;
 			});
 			this.comm.current.sendVideo(args);
 		}

--- a/console/src/views/Home.js
+++ b/console/src/views/Home.js
@@ -13,8 +13,9 @@ import AppContextConnect from '../App/AppContextConnect';
 import CompactAppList from '../components/CompactAppList';
 import CompactHvac from '../components/CompactHVAC';
 import CompactMap from '../components/CompactMap';
-import {CompactMultimedia, CompactScreenMonitor} from '../components/CompactMultimedia';
-// import CompactMusic from '../components/CompactMusic';
+import CompactMultimedia from '../components/CompactMultimedia';
+import CompactMusic from '../components/CompactMusic';
+import CompactScreenMonitor from '../components/CompactScreenMonitor';
 import CompactWeather from '../components/CompactWeather';
 
 import css from './Home.less';
@@ -216,6 +217,7 @@ const Home = kind({
 			<HomeLayout arrangeable={arrangeable}>
 				<tray1><CompactAppList icon="list" onExpand={onCompactExpand} /></tray1>
 				<tray2><CompactHvac icon="temperature" onExpand={onCompactExpand} /></tray2>
+				<tray3><CompactMusic icon="audio" onExpand={onCompactExpand} /></tray3>
 
 				<small1><CompactWeather icon="climate" onExpand={onCompactExpand} /></small1>
 				<small2><CompactScreenMonitor onExpand={onCompactExpand} /></small2>

--- a/console/src/views/Home.js
+++ b/console/src/views/Home.js
@@ -13,8 +13,8 @@ import AppContextConnect from '../App/AppContextConnect';
 import CompactAppList from '../components/CompactAppList';
 import CompactHvac from '../components/CompactHVAC';
 import CompactMap from '../components/CompactMap';
-import CompactMultimedia from '../components/CompactMultimedia';
-import CompactMusic from '../components/CompactMusic';
+import {CompactMultimedia, CompactScreenMonitor} from '../components/CompactMultimedia';
+// import CompactMusic from '../components/CompactMusic';
 import CompactWeather from '../components/CompactWeather';
 
 import css from './Home.less';
@@ -218,7 +218,7 @@ const Home = kind({
 				<tray2><CompactHvac icon="temperature" onExpand={onCompactExpand} /></tray2>
 
 				<small1><CompactWeather icon="climate" onExpand={onCompactExpand} /></small1>
-				<small2><CompactMusic icon="audio" onExpand={onCompactExpand} /></small2>
+				<small2><CompactScreenMonitor onExpand={onCompactExpand} /></small2>
 				<medium><CompactMultimedia icon="resumeplay" onExpand={onCompactExpand} onSendVideo={onSendVideo} screenIds={[1]} /></medium>
 				<large><CompactMap icon="compass" onExpand={onCompactExpand} /></large>
 			</HomeLayout>


### PR DESCRIPTION
Adds a `CompactScreenMonitor` widget that displays the poster image for videos playing on additional screens.  It expands to the full `Multimedia` app so users can change what it is broadcasting quickly.