### PR TITLE
PLAT-71503: Cleanup Copper sidebar (and match the new design)

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -2,9 +2,10 @@
 import kind from '@enact/core/kind';
 import {add} from '@enact/core/keymap';
 import {adaptEvent, forward, handle} from '@enact/core/handle';
-import {Cell, Column} from '@enact/ui/Layout';
+import {Cell, Column, Row} from '@enact/ui/Layout';
 import AgateDecorator from '@enact/agate/AgateDecorator';
 import Button from '@enact/agate/Button';
+import IconButton from '@enact/agate/IconButton';
 import Popup from '@enact/agate/Popup';
 import DateTimePicker from '@enact/agate/DateTimePicker';
 import {TabbedPanels} from '@enact/agate/Panels';
@@ -16,7 +17,7 @@ import PropTypes from 'prop-types';
 import ServiceLayer from '../data/ServiceLayer';
 
 // Components
-import ProfileDrawer from '../components/ProfileDrawer';
+import UserSelectionPopup from '../components/UserSelectionPopup';
 import UserAvatar from '../components/UserAvatar';
 import Clock from '../components/Clock';
 import WelcomePopup from '../components/WelcomePopup';
@@ -60,6 +61,32 @@ const panelIndexMap = [
 // Look up a panel index by name, using the above list as the directory listing.
 const getPanelIndexOf = (panelName) => panelIndexMap.indexOf(panelName);
 
+const PanelSwitchingIconButton = kind({
+	name: 'PanelSwitchingIconButton',
+	propTypes: {
+		index: PropTypes.number,
+		onSelect: PropTypes.func,
+		view: PropTypes.string
+	},
+	defaultProps: {
+		view: 'home'
+	},
+	handlers: {
+		onSelect: handle(
+			adaptEvent((ev, {view}) => ({view}), forward('onSelect'))
+		)
+	},
+	computed: {
+		selected: ({index, view}) => (index === getPanelIndexOf(view))
+	},
+	render: ({onSelect, ...rest}) => {
+		delete rest.index;
+		return (
+			<IconButton {...rest} onClick={onSelect} />
+		);
+	}
+});
+
 const AppBase = kind({
 	name: 'App',
 
@@ -73,11 +100,16 @@ const AppBase = kind({
 	},
 
 	handlers: {
-		onToggleProfileEdit: (ev, {updateAppState}) => {
+		layoutArrangeableToggle: (ev, {updateAppState}) => {
 			updateAppState((state) => {
-				state.appState.showProfileEdit = !state.appState.showProfileEdit;
+				state.userSettings.arrangements.arrangeable = !state.userSettings.arrangements.arrangeable;
 			});
 		},
+		// onToggleProfileEdit: (ev, {updateAppState}) => {
+		// 	updateAppState((state) => {
+		// 		state.appState.showProfileEdit = !state.appState.showProfileEdit;
+		// 	});
+		// },
 		onToggleDateTimePopup: (ev, {updateAppState}) => {
 			updateAppState((state) => {
 				state.appState.showDateTimePopup = !state.appState.showDateTimePopup;
@@ -103,6 +135,11 @@ const AppBase = kind({
 				state.appState.showBasicPopup = !state.appState.showBasicPopup;
 			});
 		},
+		onToggleUserSelectionPopup: (ev, {updateAppState}) => {
+			updateAppState((state) => {
+				state.appState.showUserSelectionPopup = !state.appState.showUserSelectionPopup;
+			});
+		},
 		onResetAll: (ev, {onSelect, updateAppState}) => {
 			onSelect({index: 0});
 			updateAppState((state) => {
@@ -118,13 +155,15 @@ const AppBase = kind({
 	render: ({
 		index,
 		layoutArrangeable,
+		layoutArrangeableToggle,
 		onResetAll,
 		onSelect,
 		onToggleBasicPopup,
 		onToggleDateTimePopup,
 		onToggleDestinationReachedPopup,
 		onTogglePopup,
-		onToggleProfileEdit,
+		// onToggleProfileEdit,
+		onToggleUserSelectionPopup,
 		onToggleWelcomePopup,
 		orientation,
 		resetCopilot,
@@ -163,25 +202,58 @@ const AppBase = kind({
 					index={index}
 				>
 					<beforeTabs>
-						<div style={{textAlign: 'center'}}>
-							<UserAvatar
-								userId={userId - 1}
-								onClick={onToggleProfileEdit}
-								style={{margin: (orientation === 'horizontal' ? '2em 1em' : '0.25em 1em')}}
-							/>
-						</div>
+						{skinName === 'copper' ? (
+							<div style={{marginLeft: '2em'}}>
+								<UserAvatar
+									userId={userId - 1}
+									onClick={onToggleUserSelectionPopup}
+									style={{margin: '1em 0 0.5em 0'}}
+								/>
+								<Clock style={{textAlign: 'left'}} />
+							</div>
+						) : (
+							<div style={{textAlign: 'center', margin: '0 0.5em 0.5em 0.5em'}}>
+								<UserAvatar
+									userId={userId - 1}
+									onClick={onToggleUserSelectionPopup}
+									style={{margin: '1em'}}
+								/>
+							</div>
+						)}
 					</beforeTabs>
 					<afterTabs>
-						<Column align="center space-around">
-							<Cell shrink style={{margin: '0.25em 1em'}}>
-								<Clock />
+						<Column
+							align={(skinName === 'copper' ? 'start center' : 'center space-around')}
+							style={{margin: (skinName === 'copper' ? '0 0 3em 2em' : '0.25em 1em 1em 1em')}}
+						>
+							{skinName === 'copper' ? null : <Cell shrink><Clock /></Cell>}
+							<Cell shrink style={{margin: (skinName === 'copper' ? 0 : '0.25em 1em 1em 1em')}}>
+								<Row align={(skinName === 'copper' ? 'center start' : 'center space-around')}>
+									<Cell shrink>
+										<PanelSwitchingIconButton
+											index={index}
+											onSelect={onSelect}
+											view="settings/theme"
+										>
+											edit
+										</PanelSwitchingIconButton>
+									</Cell>
+									<Cell shrink>
+										<IconButton
+											onClick={layoutArrangeableToggle}
+											selected={layoutArrangeable}
+										>
+											display
+										</IconButton>
+									</Cell>
+								</Row>
 							</Cell>
 						</Column>
 					</afterTabs>
 					<Home
 						arrangeable={layoutArrangeable}
 						onCompactExpand={onSelect}
-						// onSelect={onSelect}
+						onSelect={onSelect}
 						onSendVideo={sendVideo}
 					/>
 					<Phone arrangeable={layoutArrangeable} />
@@ -206,7 +278,14 @@ const AppBase = kind({
 					/>
 					<Multimedia onSendVideo={sendVideo} screenIds={[0, 1, 2]} />
 				</TabbedPanels>
-				<ProfileDrawer
+				<UserSelectionPopup
+					onClose={onToggleUserSelectionPopup}
+					onResetAll={onResetAll}
+					open={showUserSelectionPopup}
+					onResetPosition={resetPosition}
+					onResetCopilot={resetCopilot}
+				/>
+				{/* <ProfileDrawer
 					index={index}
 					getPanelIndexOf={getPanelIndexOf}
 					onProfileEditEnd={onToggleProfileEdit}
@@ -215,7 +294,7 @@ const AppBase = kind({
 					onResetCopilot={resetCopilot}
 					onSelect={onSelect}
 					showUserSelectionPopup={showUserSelectionPopup}
-				/>
+				/>*/}
 				<Popup
 					onClose={onToggleBasicPopup}
 					open={showBasicPopup}

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -149,7 +149,16 @@ const AppBase = kind({
 				state.appState.showUserSelectionPopup = false;
 				state.appState.showWelcomePopup = true;
 			});
-		}
+		},
+		onSelect: handle(
+			forward('onSelect'),
+			(ev, {updateAppState}) => {
+				updateAppState((state) => {
+					// turn off arrangeable when switching panels.
+					state.userSettings.arrangements.arrangeable = false;
+				});
+			}
+		)
 	},
 
 	render: ({

--- a/console/src/components/Clock/Clock.js
+++ b/console/src/components/Clock/Clock.js
@@ -1,6 +1,5 @@
 import kind from '@enact/core/kind';
 import hoc from '@enact/core/hoc';
-import {Layout, Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -43,10 +42,10 @@ const ClockBase = kind({
 	},
 
 	render: ({date, dayOfWeek, month, time, ...rest}) => (
-		<Layout align="center" {...rest}>
-			<Cell shrink className={css.date}>{dayOfWeek}, {month} {date.getDate()}</Cell>
-			<Cell shrink className={css.time}>{time}</Cell>
-		</Layout>
+		<div {...rest}>
+			{dayOfWeek}, {month} {date.getDate()} <wbr />
+			{time}
+		</div>
 	)
 });
 
@@ -58,7 +57,10 @@ const Tick = hoc((config, Wrapped) => {
 			this.state = {
 				date: new Date()
 			};
-			window.setInterval(this.update, 1000);
+			this.ticker = window.setInterval(this.update, 1000);
+		}
+		componentWillUnmount () {
+			window.clearInterval(this.ticker);
 		}
 		update = () => this.setState({date: new Date()})
 		render () {

--- a/console/src/components/Clock/Clock.less
+++ b/console/src/components/Clock/Clock.less
@@ -2,9 +2,6 @@
 //
 
 .clock {
-	.date,
-	.time {
-		width: 6em;
-		text-align: center;
-	}
+	text-align: center;
+	white-space: nowrap;
 }


### PR DESCRIPTION
Proposed a compromise and get design input from UX. This is the result.

Copper theme specifically needs all sidebar elements left aligned, which this does. It also repositions the clock.

The App.js `beforeTabs` and `afterTabs` section looks like a big gross mess, and that perception isn't wrong. I didn't have a better idea of how to make that code more maintainable (nice). Very open to suggestions, as well as help; but this can work.

Also:
Fixed an unmount bug, and a bug related to tapping an icon on the CompactAppList