### PR TITLE
PLAT-71788: Wider popup for date time selection

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -321,6 +321,7 @@ const AppBase = kind({
 					</buttons>
 				</Popup>
 				<Popup
+					className={css.dateTimePopup}
 					onClose={onToggleDateTimePopup}
 					open={showDateTimePopup}
 					closeButton

--- a/console/src/App/App.less
+++ b/console/src/App/App.less
@@ -1,3 +1,5 @@
+@import "~@enact/agate/styles/skin.less";
+
 .app {
 	// styles can be put here
 	// This should prevent iOS from double-tap-to-zoom but... it doesn't completely.
@@ -20,6 +22,12 @@
 		}
 	}
 }
+
+.applySkins({
+	.dateTimePopup {
+		min-width: 990px;
+	}
+});
 
 // Theme-specific rules
 :global(.copper),


### PR DESCRIPTION
PLAT-71788 - Date and Time: Year digits are cut
Specified wider `min-width`
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com