### PR TITLE
PLAT-71791: Pushed the map to the boundary of the widget frame and Panel

### DIFF
--- a/console/src/App/App.less
+++ b/console/src/App/App.less
@@ -18,7 +18,7 @@
 		margin: 0.25em 1em 1em 1em;
 
 		.buttons {
-			margin: 0.25em 1em 1em 1em
+			margin: 0.25em 1em 1em 1em;
 		}
 	}
 }
@@ -49,6 +49,24 @@
 
 			.buttons {
 				margin: 0;
+			}
+		}
+	}
+}
+:global(.carbon) {
+	.app {
+		.beforeTabs {
+			margin: 0 0.5em;
+
+			.avatar {
+				margin: 0 1em;
+			}
+		}
+		.afterTabs {
+			margin: 0 1em;
+
+			.buttons {
+				margin: 0.25em 1em;
 			}
 		}
 	}

--- a/console/src/App/App.less
+++ b/console/src/App/App.less
@@ -63,7 +63,7 @@
 			}
 		}
 		.afterTabs {
-			margin: 0 1em;
+			margin: 0.25em 1em;
 
 			.buttons {
 				margin: 0.25em 1em;

--- a/console/src/components/CompactAppList/CompactAppList.js
+++ b/console/src/components/CompactAppList/CompactAppList.js
@@ -33,7 +33,7 @@ const CompactAppList = kind({
 			<DropRow align="start space-around" wrap>
 				<AppIconCell
 					shrink
-					size="24%"
+					size="50%"
 					icon="compass"
 					data-tabindex={getPanelIndexOf('map')}
 					onClick={onTabChange}
@@ -42,7 +42,7 @@ const CompactAppList = kind({
 				</AppIconCell>
 				<AppIconCell
 					shrink
-					size="24%"
+					size="50%"
 					icon="audio"
 					onKeyUp={onTabChange}
 					data-tabindex={getPanelIndexOf('radio')}
@@ -52,7 +52,7 @@ const CompactAppList = kind({
 				</AppIconCell>
 				<AppIconCell
 					shrink
-					size="24%"
+					size="50%"
 					icon="rearscreen"
 					data-tabindex={getPanelIndexOf('multimedia')}
 					onKeyUp={onTabChange}
@@ -62,7 +62,7 @@ const CompactAppList = kind({
 				</AppIconCell>
 				<AppIconCell
 					shrink
-					size="24%"
+					size="50%"
 					icon="gear"
 					data-tabindex={getPanelIndexOf('settings')}
 					onKeyUp={onTabChange}

--- a/console/src/components/CompactMap/CompactMap.less
+++ b/console/src/components/CompactMap/CompactMap.less
@@ -2,4 +2,5 @@
 //
 
 .compactMap {
+	padding: 0;
 }

--- a/console/src/components/DestinationList/DestinationList.js
+++ b/console/src/components/DestinationList/DestinationList.js
@@ -1,6 +1,5 @@
 import Divider from '@enact/agate/Divider';
 import kind from '@enact/core/kind';
-import {Column, Cell} from '@enact/ui/Layout';
 import Button from '@enact/agate/Button';
 import Group from '@enact/ui/Group';
 import React from 'react';
@@ -46,23 +45,20 @@ const DestinationList = kind({
 
 	render: ({positions, onSetDestination, selected, title, ...rest}) => {
 		return (
-			<Column {...rest}>
-				<Cell component={Divider} shrink className={css.heading}>{title}</Cell>
-				<Cell>
-					<Column
-						component={Group}
-						childComponent={Cell}
-						onSelect={onSetDestination}
-						selectedProp="highlighted"
-						selected={selected}
-						itemProps={{component: DestinationButton, shrink: true}}
-					>
-						{
-							positions.map(({description}, index) => `${index + 1} - ${description}`)
-						}
-					</Column>
-				</Cell>
-			</Column>
+			<div {...rest}>
+				<Divider spacing="medium" className={css.heading}>{title}</Divider>
+				<Group
+					component="div"
+					childComponent={DestinationButton}
+					onSelect={onSetDestination}
+					selectedProp="highlighted"
+					selected={selected}
+				>
+					{
+						positions.map(({description}, index) => `${index + 1} - ${description}`)
+					}
+				</Group>
+			</div>
 		);
 	}
 });

--- a/console/src/components/DestinationList/DestinationList.less
+++ b/console/src/components/DestinationList/DestinationList.less
@@ -9,6 +9,7 @@
 
 .button {
 	.applySkins({
+		display: block;
 		margin-top: 15px;
 
 		.bg {

--- a/console/src/components/MapController/MapController.js
+++ b/console/src/components/MapController/MapController.js
@@ -188,7 +188,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 							{
 								autonomousSelection &&
 								<Cell shrink={locationSelection} className={css.columnCell}>
-									<Divider className={css.heading}>Self Driving</Divider>
+									<Divider spacing="medium" className={css.heading}>Self Driving</Divider>
 									<Row
 										component={Group}
 										childComponent={Cell}

--- a/console/src/components/MapController/MapController.less
+++ b/console/src/components/MapController/MapController.less
@@ -2,7 +2,7 @@
 
 .map {
 	.columnCell {
-		margin-top: 2em;
+		margin-top: 1em;
 
 		&:first-child {
 			margin-top: 0;
@@ -29,11 +29,11 @@
 
 	.applySkins({
 		.travelInfo {
-			background-image: radial-gradient(@agate-background-active, transparent 75%);
 
 			.number {
 				font-size: 180%;
 				color: @agate-highlight;
+				text-shadow: 0 1px 3px black, 0 3px 9px fade(black, 25%);
 			}
 		}
 	});

--- a/console/src/views/Home.js
+++ b/console/src/views/Home.js
@@ -213,7 +213,7 @@ const Home = kind({
 	},
 
 	render: ({arrangeable, onCompactExpand, onSendVideo, onSelect, ...rest}) => (
-		<Panel {...rest}>
+		<Panel {...rest} css={css}>
 			<HomeLayout arrangeable={arrangeable}>
 				<tray1><CompactHvac onExpand={onCompactExpand} /></tray1>
 				<tray2><CompactAppList onExpand={onCompactExpand} onSelect={onSelect} /></tray2>

--- a/console/src/views/Home.less
+++ b/console/src/views/Home.less
@@ -4,6 +4,14 @@
 @import "~@enact/agate/styles/mixins.less";
 @import "~@enact/agate/styles/skin.less";
 
+.homePanel {
+	.applySkins({
+		.body {
+			padding: 0;
+		}
+	});
+}
+
 .home {
 	height: 100%;
 
@@ -34,7 +42,6 @@
 	.small2,
 	.medium,
 	.large {
-		margin: 6px;
 
  		&[draggable="true"] {
 			&::after {


### PR DESCRIPTION
Updated CompactAppList to still look correct given the new amount of space available.
Simplified DestinationList since it doesn't need to leverage Column's #realultimatepower.
Refactored the background shadow behind the trip info so it stands out better.