### PR TITLE
PLAT-71438: Update welcome screen media layout

### DIFF
--- a/console/src/components/CompactHeater/CompactHeater.js
+++ b/console/src/components/CompactHeater/CompactHeater.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ToggleButton from '@enact/agate/ToggleButton';
+// import ToggleButton from '@enact/agate/ToggleButton';
+import LabeledIconButton from '@enact/agate/LabeledIconButton';
+import Skinnable from '@enact/agate/Skinnable';
 import kind from '@enact/core/kind';
-import {Cell, Row} from '@enact/ui/Layout';
+import {Cell} from '@enact/ui/Layout';
 
 import AppStateConnect from '../../App/AppContextConnect';
 import Widget from '../Widget';
@@ -41,31 +43,49 @@ const CompactHeaterBase = kind({
 	},
 
 	computed: {
-		leftStatus: ({leftHeat}) => leftHeat ? 'on' : 'off',
-		rightStatus: ({rightHeat}) => rightHeat ? 'on' : 'off'
+		leftStatus: ({leftHeat, styler}) => <span className={styler.join('status', {on: leftHeat})}>{leftHeat ? 'ON' : 'OFF'}</span>,
+		rightStatus: ({rightHeat, styler}) => <span className={styler.join('status', {on: rightHeat})}>{rightHeat ? 'ON' : 'OFF'}</span>
 	},
 
 	render: ({leftHeat, leftStatus, onToggleLeftHeater, onToggleRightHeater, rightHeat, rightStatus, ...rest}) => {
 		delete rest.updateAppState;
 		return (
 
-			<Widget {...rest} title="Heated Seats" description="Warm up the seats" view="hvac" align="stretch center">
-				{/* <Row>*/}
+			<Widget {...rest} title="Heated Seats" description="Warm up the seats" view="hvac" align="center space-around" orientation="horizontal">
 				<Cell shrink>
-					<Row align="center space-around">
-						<Cell shrink><ToggleButton icon="heatseatleft" onClick={onToggleLeftHeater} selected={leftHeat} underline /></Cell>
-						<Cell shrink><ToggleButton icon="heatseatright" onClick={onToggleRightHeater} selected={rightHeat} underline /></Cell>
-					</Row>
+					<LabeledIconButton
+						icon="heatseatleft"
+						onClick={onToggleLeftHeater}
+						selected={leftHeat}
+					>
+						Left: {leftStatus}
+					</LabeledIconButton>
 				</Cell>
 				<Cell shrink>
-					<Row align="center space-around">
-						<Cell shrink>Left: {leftStatus}</Cell>
-						<Cell shrink>Right: {rightStatus}</Cell>
-					</Row>
+					<LabeledIconButton
+						icon="heatseatright"
+						onClick={onToggleRightHeater}
+						selected={rightHeat}
+					>
+						Right: {rightStatus}
+					</LabeledIconButton>
 				</Cell>
-				{/* </Row>*/}
 			</Widget>
 		);
+		// {/* <Row>*/}
+		// <Cell shrink>
+		// 	<Row align="center space-around">
+		// 		<Cell shrink><ToggleButton icon="heatseatleft" onClick={onToggleLeftHeater} selected={leftHeat} underline /></Cell>
+		// 		<Cell shrink><ToggleButton icon="heatseatright" onClick={onToggleRightHeater} selected={rightHeat} underline /></Cell>
+		// 	</Row>
+		// </Cell>
+		// <Cell shrink>
+		// 	<Row align="center space-around">
+		// 		<Cell shrink>Left: {leftStatus}</Cell>
+		// 		<Cell shrink>Right: {rightStatus}</Cell>
+		// 	</Row>
+		// </Cell>
+		// {/* </Row>*/}
 	}
 });
 
@@ -73,6 +93,6 @@ const CompactHeater = AppStateConnect(({userSettings: {climate}, updateAppState}
 	leftHeat: (climate && climate.leftHeat),
 	rightHeat: (climate && climate.rightHeat),
 	updateAppState
-}))(CompactHeaterBase);
+}))(Skinnable(CompactHeaterBase));
 
 export default CompactHeater;

--- a/console/src/components/CompactHeater/CompactHeater.less
+++ b/console/src/components/CompactHeater/CompactHeater.less
@@ -1,3 +1,19 @@
+@import "~@enact/agate/styles/skin.less";
+
 .compactHeater {
 	height: 100%;
+	letter-spacing: 12px;
+
+	.applySkins({
+		.status {
+			font-weight: 900;
+			width: 3em;
+			display: inline-block;
+			text-align: left;
+		}
+
+		.on {
+			color: @agate-highlight;
+		}
+	});
 }

--- a/console/src/components/CompactMultimedia/CompactMultimedia.js
+++ b/console/src/components/CompactMultimedia/CompactMultimedia.js
@@ -59,6 +59,7 @@ const CompactMultimediaBase = kind({
 				>
 					<ResponsiveVirtualList
 						dataSize={videos.length}
+						direction="horizontal"
 						onSelectVideo={onSelectVideo}
 						size={size}
 						videos={videos}

--- a/console/src/components/CompactMultimedia/CompactMultimedia.js
+++ b/console/src/components/CompactMultimedia/CompactMultimedia.js
@@ -1,4 +1,5 @@
 import kind from '@enact/core/kind';
+import {Cell, Column} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -6,7 +7,7 @@ import {WidgetBase, WidgetDecorator} from '../Widget';
 import {ScreenSelectionPopup} from '../../../../components/ScreenSelectionPopup';
 import {MultimediaDecorator, ResponsiveVirtualList} from '../../views/Multimedia';
 
-import css from './CompactMultimedia.less';
+import componentCss from './CompactMultimedia.less';
 
 const CompactMultimediaBase = kind({
 	name: 'CompactMultimedia',
@@ -15,6 +16,8 @@ const CompactMultimediaBase = kind({
 		screenIds: PropTypes.array.isRequired,
 		adContent: PropTypes.any,
 		containerShape: PropTypes.object,
+		css: PropTypes.object,
+		direction: PropTypes.string,
 		onClosePopup: PropTypes.func,
 		onSelectVideo: PropTypes.func,
 		onSendVideo: PropTypes.func,
@@ -24,17 +27,18 @@ const CompactMultimediaBase = kind({
 	},
 
 	styles: {
-		css,
-		className: 'compactMultimedia'
+		css: componentCss,
+		className: 'compactMultimedia',
+		publicClassNames: true
 	},
 
 	computed: {
 		className: ({containerShape: {size: {relative = 'small'}}, styler}) => {
-			return styler.append(relative && css[relative]);
+			return styler.append(relative && componentCss[relative]);
 		}
 	},
 
-	render: ({containerShape, onClosePopup, onSelectVideo, onSendVideo, screenIds, showPopup, videos, ...rest}) => {
+	render: ({containerShape, css, direction, onClosePopup, onSelectVideo, onSendVideo, screenIds, showPopup, videos, ...rest}) => {
 		delete rest.adContent;
 		delete rest.showAd;
 
@@ -57,13 +61,17 @@ const CompactMultimediaBase = kind({
 					description="Send videos and music to the rear screen(s)"
 					view="multimedia"
 				>
-					<ResponsiveVirtualList
-						dataSize={videos.length}
-						direction="horizontal"
-						onSelectVideo={onSelectVideo}
-						size={size}
-						videos={videos}
-					/>
+					<Cell className={css.list}>
+						<Column>
+							<ResponsiveVirtualList
+								dataSize={videos.length}
+								direction={direction}
+								onSelectVideo={onSelectVideo}
+								size={size}
+								videos={videos}
+							/>
+						</Column>
+					</Cell>
 				</WidgetBase>
 			</React.Fragment>
 		);

--- a/console/src/components/CompactMultimedia/CompactMultimedia.less
+++ b/console/src/components/CompactMultimedia/CompactMultimedia.less
@@ -1,6 +1,10 @@
 .compactMultimedia {
 	width: 100%;
 
+	.list {
+		margin: 0;
+	}
+
 	&.medium {
 
 		.rearScreenImage {

--- a/console/src/components/MapController/MapController.js
+++ b/console/src/components/MapController/MapController.js
@@ -19,7 +19,10 @@ import {formatDuration, formatTime} from '../../../../components/Formatter';
 
 import css from './MapController.less';
 
-const StyledButton = (props) => (<Button {...props} css={css} />);
+const StyledButton = ({style = {}, ...rest}) => {
+	style.width = 'auto';  // Allow the buttons to properly self-size. Margins + auto-sizing confuses relatively positioned elements with 0 width and flex.
+	return <Button {...rest} style={style} css={css} />;
+};
 
 const MapControllerHoc = hoc((configHoc, Wrapped) => {
 	return class extends React.Component {

--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -50,7 +50,7 @@ const getMapPadding = () => {
 		top: ri.scale(edgeClearance),
 		bottom:ri.scale(edgeClearance),
 		left: ri.scale(edgeClearance),
-		right: ri.scale(384 + edgeClearance)
+		right: ri.scale(426 + 36 + edgeClearance) // Tools width + right edge padding + edgeClearance.
 	};
 };
 

--- a/console/src/components/MapCore/MapCore.less
+++ b/console/src/components/MapCore/MapCore.less
@@ -3,6 +3,7 @@
 
 @import "https://api.tiles.mapbox.com/mapbox-gl-js/v0.49.0/mapbox-gl.css";
 @import "~@enact/agate/styles/mixins.less";
+@import "~@enact/agate/styles/skin.less";
 
 .map {
 	&,
@@ -32,6 +33,28 @@
 		}
 	}
 }
+
+.applySkins({
+	.map {
+		// &::before {
+		// 	background-image: radial-gradient(hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0%), var(--agate-accent-l, 0%), 0.2), transparent 60%), linear-gradient(to bottom, #14191d 43%, #040213 90%);
+		// 	content: "";
+		// 	display: block;
+		// 	position: absolute;
+		// 	.position(0);
+		// 	pointer-events: none;
+		// }
+		&::after {
+			background-image: @agate-bg-image2;//, linear-gradient(to bottom, rgba(20, 25, 29, 0.6) 0%, transparent 30%, transparent 70%, rgba(4, 2, 19, 0.6) 100%);
+			background-blend-mode: hard-light;
+			content: "";
+			display: block;
+			position: absolute;
+			.position(0);
+			pointer-events: none;
+		}
+	}
+});
 
 // We don't want the empty tools column area to be an invisible unclickable space
 // This selector is here instead of above due to a precedence race-condition

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -28,10 +28,10 @@ const getCompactComponent = ({components, key, onSendVideo}) => {
 
 	switch (components[key]) {
 		case 'multimedia':
-			Component = (<CompactMultimedia noExpandButton onSendVideo={onSendVideo} screenIds={[1]} />);
+			Component = (<CompactMultimedia css={css} direction="horizontal" noExpandButton onSendVideo={onSendVideo} screenIds={[1]} />);
 			break;
 		case 'heater':
-			Component = (<CompactHeater noExpandButton />);
+			Component = (<CompactHeater className={css.compactHeater} noExpandButton />);
 			break;
 		default:
 			Component = (<CompactWeather noExpandButton />);
@@ -151,11 +151,11 @@ const WelcomePopupBase = kind({
 				{/* <Panels arranger={Arranger} index={index} enteringProp="hideChildren" onTransition={handleTransition}> */}
 				{/* <UserSelectionPanel users={usersList} onSelectUser={onSelectUser} /> */}
 				{/* <WelcomePanel /> */}
-				<Panel>
+				<Panel css={css}>
 					<Row className={css.welcome}>
 						<Cell className={css.left} size="33%">
 							<Column>
-								<Cell shrink>
+								<Cell className={css.profile} shrink>
 									<Row>
 										<Cell className={css.avatar} shrink>
 											<UserAvatar css={css} userId={userId - 1} /* onClick={onCancelSelect} */ />
@@ -168,7 +168,7 @@ const WelcomePopupBase = kind({
 										</Cell>
 									</Row>
 								</Cell>
-								<Cell shrink>
+								<Cell className={css.time} shrink>
 									{currentTime()}
 								</Cell>
 								<Cell className={css.smallComponent}>
@@ -177,7 +177,7 @@ const WelcomePopupBase = kind({
 								<Cell className={css.smallComponent}>
 									{Small2Component}
 								</Cell>
-								<Cell component={Button} highlighted onClick={handleClose} shrink>{"Let's Go!"}</Cell>
+								<Cell component={Button} className={css.button} highlighted onClick={handleClose} shrink>{"Let's Go!"}</Cell>
 							</Column>
 						</Cell>
 						<Cell>

--- a/console/src/components/WelcomePopup/WelcomePopup.js
+++ b/console/src/components/WelcomePopup/WelcomePopup.js
@@ -1,5 +1,5 @@
 import Button from '@enact/agate/Button';
-// import Divider from '@enact/agate/Divider';
+import Divider from '@enact/agate/Divider';
 import FullscreenPopup from '@enact/agate/FullscreenPopup';
 // import {Panel, Panels} from '@enact/agate/Panels';
 import {Panel} from '@enact/agate/Panels';
@@ -28,19 +28,19 @@ const getCompactComponent = ({components, key, onSendVideo}) => {
 
 	switch (components[key]) {
 		case 'multimedia':
-			Component = (<CompactMultimedia css={css} direction="horizontal" noExpandButton onSendVideo={onSendVideo} screenIds={[1]} />);
+			Component = (<CompactMultimedia className={css.widget} direction="horizontal" noExpandButton onSendVideo={onSendVideo} screenIds={[1]} />);
 			break;
 		case 'heater':
-			Component = (<CompactHeater className={css.compactHeater} noExpandButton />);
+			Component = (<CompactHeater className={css.widget} noExpandButton />);
 			break;
 		default:
-			Component = (<CompactWeather noExpandButton />);
+			Component = (<CompactWeather className={css.widget} noExpandButton />);
 	}
 
 	return Component;
 };
 
-const currentTime = () => new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
+// const currentTime = () => new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
 
 // const WelcomePanel = Skinnable({defaultSkin: 'carbon'}, Panel);
 
@@ -121,7 +121,16 @@ const WelcomePopupBase = kind({
 		// 	return users;
 		// },
 		small1Component: (props) => getCompactComponent({...props, key: 'small1'}),
-		small2Component: (props) => getCompactComponent({...props, key: 'small2'})
+		small2Component: (props) => getCompactComponent({...props, key: 'small2'}),
+		time: () => {
+			const now = new Date();
+			let h = now.getHours();
+			let m = now.getMinutes();
+			const ampm = (h >= 12 ? 'pm' : 'am');
+			if (h > 12) h -= 12;
+			if (m < 10) m = '0' + m;
+			return <React.Fragment><em>{h}:{m}</em> {ampm}</React.Fragment>;
+		}
 	},
 
 	render: ({
@@ -133,6 +142,7 @@ const WelcomePopupBase = kind({
 		profileName,
 		small1Component: Small1Component,
 		small2Component: Small2Component,
+		time,
 		userId,
 		// usersList,
 		...rest
@@ -151,33 +161,35 @@ const WelcomePopupBase = kind({
 				{/* <Panels arranger={Arranger} index={index} enteringProp="hideChildren" onTransition={handleTransition}> */}
 				{/* <UserSelectionPanel users={usersList} onSelectUser={onSelectUser} /> */}
 				{/* <WelcomePanel /> */}
-				<Panel css={css}>
+				<Panel className={css.panel} css={css}>
 					<Row className={css.welcome}>
 						<Cell className={css.left} size="33%">
 							<Column>
-								<Cell className={css.profile} shrink>
+								<Cell shrink className={css.headerCell}>
 									<Row>
 										<Cell className={css.avatar} shrink>
 											<UserAvatar css={css} userId={userId - 1} /* onClick={onCancelSelect} */ />
 										</Cell>
-										<Cell>
+										<Cell className={css.activeName}>
 											<Column align="start center">
-												<Cell shrink>Hi</Cell>
-												<Cell className={css.activeName} shrink>{profileName}!</Cell>
+												<Cell shrink>Greetings</Cell>
+												<Cell component="em" shrink>{profileName}!</Cell>
 											</Column>
 										</Cell>
 									</Row>
 								</Cell>
-								<Cell className={css.time} shrink>
-									{currentTime()}
+								<Cell shrink className={css.contentCell + ' ' + css.time}>
+									{time}
 								</Cell>
-								<Cell className={css.smallComponent}>
+								<Cell shrink className={css.contentCell + ' ' + css.divider} component={Divider} />
+								<Cell className={css.contentCell}>
 									{Small1Component}
 								</Cell>
-								<Cell className={css.smallComponent}>
+								<Cell shrink className={css.contentCell + ' ' + css.divider} component={Divider} />
+								<Cell className={css.contentCell}>
 									{Small2Component}
 								</Cell>
-								<Cell component={Button} className={css.button} highlighted onClick={handleClose} shrink>{"Let's Go!"}</Cell>
+								<Cell className={css.contentCell} component={Button} highlighted onClick={handleClose} shrink>Let&apos;s Go!</Cell>
 							</Column>
 						</Cell>
 						<Cell>

--- a/console/src/components/WelcomePopup/WelcomePopup.less
+++ b/console/src/components/WelcomePopup/WelcomePopup.less
@@ -3,26 +3,33 @@
 
 @import "~@enact/agate/styles/skin.less";
 
-@guide-border-color: rgba(255, 255, 255, 0.5);
-@side-spacing: 84px;
-
+// @guide-border-color: rgba(255, 255, 255, 0.5);
 .welcomePopup {
+	@welcome-letter-spacing: 12px;
+
 	.applySkins({
 		// suppress any transitioning for the popup
 		transition-property: none;
 
-		.panel {
-			.body {
-				padding: 0;
-			}
+		em {
+			color: @agate-highlight;
+			font-style: normal;
+		}
+
+		.time em {
+			font-size: 150%;
+		}
+
+		.panel .body {
+			padding: 0;
 		}
 
 		.welcome {
 			height: 100%;
 
-			.left {
-				margin-right: 3px;
-			}
+			// .left {
+			// 	margin-right: 3px;
+			// }
 		}
 
 		// &.useWelcomeBackground {
@@ -75,61 +82,46 @@
 		// 	}
 		// }
 
-		.profile {
-			margin: 48px @side-spacing 48px 60px;
+		.headerCell {
+			margin: 48px 60px 0 60px;
+		}
 
-			.avatar {
-				margin-right: 30px;
+		.contentCell {
+			margin: 12px 84px;
 
-				.image {
-					border-color: @agate-accent;
-				}
+			&:last-child {
+				margin-bottom: 48px;
 			}
 		}
 
-		.time {
-			margin: 0 @side-spacing 36px;
-		}
+		.avatar {
+			margin-right: 30px;
 
-		.smallComponent {
-			margin-top: 12px;
-
-			&::before {
-				content: "";
-				position: absolute;
-				// These refer to theme colors, so we'll get them updated soon after the theme is ready
-				background-image: linear-gradient(to right, rgba(0,0,0,0), @agate-accent, rgba(0,0,0,0));
-				top: -3px;
-				left: -3px;
-				right: -3px;
-				height: 1px;
-				margin: 0 @side-spacing;
+			.image {
+				border-color: @agate-accent;
 			}
 		}
 
 		.activeName {
 			font-size: 24px;
-			letter-spacing: 12px;
+			letter-spacing: @welcome-letter-spacing;
 			// This refers to theme colors, so we'll get them updated soon after the theme is ready
 			color: @agate-accent;
 		}
 
-		.compactMultimedia {
-			padding-left: @side-spacing;
-			padding-right: 0;
-		
-			.list {
-				margin: 10px 0;
-			}
+		.divider {
+			background-image: linear-gradient(to right, transparent, @agate-accent, transparent);
+			height: 1px;
+			min-height: 1px;
 		}
 
-		.compactHeater {
-			padding-left: @side-spacing;
-    		padding-right: @side-spacing;
+		.widget {
+			padding: 0;
 		}
 
-		.button {
-			margin: 0 @side-spacing 96px;
+		.time {
+			letter-spacing: @welcome-letter-spacing;
+			text-transform: uppercase;
 		}
 
 	});

--- a/console/src/components/WelcomePopup/WelcomePopup.less
+++ b/console/src/components/WelcomePopup/WelcomePopup.less
@@ -4,10 +4,18 @@
 @import "~@enact/agate/styles/skin.less";
 
 @guide-border-color: rgba(255, 255, 255, 0.5);
+@side-spacing: 84px;
+
 .welcomePopup {
 	.applySkins({
 		// suppress any transitioning for the popup
 		transition-property: none;
+
+		.panel {
+			.body {
+				padding: 0;
+			}
+		}
 
 		.welcome {
 			height: 100%;
@@ -67,13 +75,20 @@
 		// 	}
 		// }
 
-		.avatar {
-			margin-right: 30px;
-			margin-bottom: 30px;
+		.profile {
+			margin: 48px @side-spacing 48px 60px;
 
-			.image {
-				border-color: @agate-accent;
+			.avatar {
+				margin-right: 30px;
+
+				.image {
+					border-color: @agate-accent;
+				}
 			}
+		}
+
+		.time {
+			margin: 0 @side-spacing 36px;
 		}
 
 		.smallComponent {
@@ -88,6 +103,7 @@
 				left: -3px;
 				right: -3px;
 				height: 1px;
+				margin: 0 @side-spacing;
 			}
 		}
 
@@ -97,5 +113,24 @@
 			// This refers to theme colors, so we'll get them updated soon after the theme is ready
 			color: @agate-accent;
 		}
+
+		.compactMultimedia {
+			padding-left: @side-spacing;
+			padding-right: 0;
+		
+			.list {
+				margin: 10px 0;
+			}
+		}
+
+		.compactHeater {
+			padding-left: @side-spacing;
+    		padding-right: @side-spacing;
+		}
+
+		.button {
+			margin: 0 @side-spacing 96px;
+		}
+
 	});
 }

--- a/console/src/components/Widget/Widget.js
+++ b/console/src/components/Widget/Widget.js
@@ -1,7 +1,7 @@
 import {ResponsiveBox} from '@enact/agate/DropManager';
 import LabeledIconButton from '@enact/agate/LabeledIconButton';
 import kind from '@enact/core/kind';
-import {Cell, Row, Column} from '@enact/ui/Layout';
+import Layout, {Cell, Row, Column} from '@enact/ui/Layout';
 import Slottable from '@enact/ui/Slottable';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
@@ -25,13 +25,15 @@ const WidgetBase = kind({
 		noExpandButton: PropTypes.bool,
 		noHeader: PropTypes.bool,
 		onExpand: PropTypes.func,
+		orientation: PropTypes.string,
 		small: PropTypes.node,
 		title: PropTypes.string,
 		view: PropTypes.string
 	},
 
 	defaultProps: {
-		align: 'stretch center'
+		align: 'stretch center',
+		orientation: 'vertical'
 	},
 
 	styles: {
@@ -60,7 +62,7 @@ const WidgetBase = kind({
 		}
 	},
 
-	render: ({align, children, containerShape, icon, onExpand, noExpandButton, noHeader, title, view, ...rest}) => {
+	render: ({align, children, containerShape, icon, noExpandButton, noHeader, onExpand, orientation, title, view, ...rest}) => {
 		delete rest.containerShape;
 		delete rest.description;
 		delete rest.full;
@@ -86,9 +88,9 @@ const WidgetBase = kind({
 						</Cell>
 					) : null}
 					<Cell>
-						<Column align={align}>
+						<Layout align={align} orientation={orientation}>
 							{children}
-						</Column>
+						</Layout>
 					</Cell>
 				</Column>
 			);

--- a/console/src/views/Multimedia.js
+++ b/console/src/views/Multimedia.js
@@ -123,12 +123,12 @@ const ResponsiveVirtualList = kind({
 				break;
 			}
 			case 'small': {
-				List = VirtualList;
+				List = VirtualGridList;
 				direction = direction || 'vertical';
 				spacing = ri.scale(12);
 				itemSize = {
-					minWidth: ri.scale(180),
-					minHeight: ri.scale(100)
+					minWidth: ri.scale(120),
+					minHeight: ri.scale(72)
 				};
 				break;
 			}

--- a/console/src/views/Multimedia.js
+++ b/console/src/views/Multimedia.js
@@ -63,7 +63,7 @@ const ResponsiveVirtualList = kind({
 		// eslint-disable-next-line enact/display-name,enact/prop-types
 		itemRenderer: ({onSelectVideo, size, styler, videos}) => ({index, ...rest}) => {
 			const className = styler.append(css.listItem, size && css[size]);
-			if (size === 'small' || size === 'large') {
+			if (size === 'large') {
 				return (
 					<ThumbnailItem
 						{...rest}
@@ -124,9 +124,12 @@ const ResponsiveVirtualList = kind({
 			}
 			default: {
 				List = VirtualList;
-				// direction = direction || 'vertical';
-				spacing = ri.scale(15);
-				itemSize = ri.scale(90);
+				direction = direction || 'vertical';
+				spacing = ri.scale(12);
+				itemSize = {
+					minWidth: ri.scale(320),
+					minHeight: ri.scale(180)
+				};
 			}
 		}
 

--- a/console/src/views/Multimedia.js
+++ b/console/src/views/Multimedia.js
@@ -122,14 +122,21 @@ const ResponsiveVirtualList = kind({
 				};
 				break;
 			}
-			default: {
+			case 'small': {
 				List = VirtualList;
 				direction = direction || 'vertical';
 				spacing = ri.scale(12);
 				itemSize = {
-					minWidth: ri.scale(320),
-					minHeight: ri.scale(180)
+					minWidth: ri.scale(180),
+					minHeight: ri.scale(100)
 				};
+				break;
+			}
+			default: {
+				List = VirtualList;
+				// direction = direction || 'vertical';
+				spacing = ri.scale(15);
+				itemSize = ri.scale(90);
 			}
 		}
 

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -16,6 +16,8 @@ import componentCss from './Settings.less';
 const skinCollection = {
 	carbon: 'Carbon',
 	copper: 'Copper',
+	electro: 'Electro',
+	titanium: 'Titanium',
 	'copper-day': 'Copper Day'
 };
 const skinList = Object.keys(skinCollection);


### PR DESCRIPTION
This updates the `CompactMultimedia` component item layout on the welcome screen.
This task was to update the layout to 3 visible items per UX design, rather than simply the 2 existing items. As there is not much room, the 3rd item is now marginally visible, but still serves the purpose of making the scrolling easier or more natural. I wonder if we should also adjust the margins/padding of the welcome screen widgets to allow more room for content.