### PR TITLE
Add LG red to the color picker palette

### DIFF
--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -23,7 +23,7 @@ const skinCollection = {
 const skinList = Object.keys(skinCollection);
 const skinNames = skinList.map((skin) => skinCollection[skin]);  // Build the names list based on the skin list array, so the indexes always match up, in case the object keys don't return in the same order.
 
-const swatchPalette = ['#e0b094', '#ffffff', '#a47d66', '#9cd920', '#559616', '#cecacb', '#566af0', '#0359f0', '#f08c21', '#f25c54', '#f42c04', '#8d0801', '#2e1C2b', '#d636d9', '#aab3cb'];
+const swatchPalette = ['#e0b094', '#ffffff', '#a47d66', '#be064d', '#9cd920', '#559616', '#cecacb', '#566af0', '#0359f0', '#f08c21', '#f25c54', '#f42c04', '#8d0801', '#2e1C2b', '#d636d9', '#aab3cb'];
 
 const FormRow = kind({
 	name: 'FormRow',

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -23,7 +23,12 @@ const skinCollection = {
 const skinList = Object.keys(skinCollection);
 const skinNames = skinList.map((skin) => skinCollection[skin]);  // Build the names list based on the skin list array, so the indexes always match up, in case the object keys don't return in the same order.
 
-const swatchPalette = ['#e0b094', '#ffffff', '#a47d66', '#be064d', '#9cd920', '#559616', '#cecacb', '#566af0', '#0359f0', '#f08c21', '#f25c54', '#f42c04', '#8d0801', '#2e1C2b', '#d636d9', '#aab3cb'];
+const swatchPalette = [
+	'#e0b094', '#ffffff', '#a47d66', '#be064d',
+	'#9cd920', '#559616', '#75d1f0', '#259aa7',
+	'#cecacb', '#566af0', '#0359f0', '#f08c21',
+	'#f25c54', '#f42c04', '#d636d9', '#aab3cb'
+];
 
 const FormRow = kind({
 	name: 'FormRow',


### PR DESCRIPTION
Added LG red color (#be064d ). It's neither the moonstone accent color (#cf0652) nor the official LG Red (#990033), but it's somewhere in between. moonstone accent color seemed too pink, and LG Red seemed too dark. 

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>