### PR TITLE
PLAT-71622 - Added move layer after direction draw

### DIFF
--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -634,7 +634,9 @@ class MapCoreBase extends React.Component {
 				});
 			}
 
-			this.map.moveLayer(carLayerId);
+			if (this.map.getLayer(carLayerId)) {
+				this.map.moveLayer(carLayerId);
+			}
 			this.props.updateNavigation({
 				duration: route.duration,
 				distance: route.distance

--- a/console/src/components/MapCore/MapCore.js
+++ b/console/src/components/MapCore/MapCore.js
@@ -634,6 +634,7 @@ class MapCoreBase extends React.Component {
 				});
 			}
 
+			this.map.moveLayer(carLayerId);
 			this.props.updateNavigation({
 				duration: route.duration,
 				distance: route.distance


### PR DESCRIPTION
Pretty much just moving the car layer every time a route is drawn. This will just make sure the car is always on top 

https://www.mapbox.com/mapbox-gl-js/api/#map#movelayer