### PR TITLE
Hide extra skins for the demo

### DIFF
--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -16,8 +16,8 @@ import componentCss from './Settings.less';
 const skinCollection = {
 	carbon: 'Carbon',
 	copper: 'Copper',
-	electro: 'Electro',
-	titanium: 'Titanium',
+	// electro: 'Electro',
+	// titanium: 'Titanium',
 	'copper-day': 'Copper Day'
 };
 const skinList = Object.keys(skinCollection);


### PR DESCRIPTION
This was supposed to have been done in an earlier PR, but I made a mistake with merging and lost this change.