### PR TITLE
PLAT-71799: Update CompactMusic widget layout

### DIFF
--- a/console/src/components/CompactMusic/CompactMusic.js
+++ b/console/src/components/CompactMusic/CompactMusic.js
@@ -45,6 +45,7 @@ const CompactMusicBase = kind({
 				<Cell shrink>
 					<GridListImageItem
 						caption="The Title"
+						css={css}
 						className={css.album}
 						selectionOverlay={PlaybackControls}
 						selectionOverlayShowing

--- a/console/src/components/CompactMusic/CompactMusic.less
+++ b/console/src/components/CompactMusic/CompactMusic.less
@@ -1,6 +1,10 @@
 .compactMusic {
 	.album {
-		width: 246px;
+		width: 207px;
+	
+		.caption {
+			margin-top: 12px;
+		}
 	}
 
 	.playbackControls {


### PR DESCRIPTION
Add `margin-top` to caption so that the spacing of title and album seem uniform.

Note: Reduced the width of album art to fit in `carbon` skin.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>