### PR TITLE
PLAT-71789: Fix Colorpicker bleeding off-screen

### DIFF
--- a/console/src/views/Settings.less
+++ b/console/src/views/Settings.less
@@ -6,6 +6,10 @@
 	.content {
 		justify-content: center;
 		min-width: 432px;
+
+		.formRow {
+			margin: 0 18px;
+		}
 	}
 
 	.switchItem {

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -105,7 +105,7 @@ const ThemeSettings = kind({
 								Theme
 						</Cell>
 						<Cell shrink className={css.spacedItem}>
-							<FormRow align="start space-around" alignLabel="center">
+							<FormRow align="start space-around" alignLabel="center" className={css.formRow}>
 								<AccentColorSetting label="Accent Color">{swatchPalette}</AccentColorSetting>
 								<HighlightColorSetting label="Highlight Color">{swatchPalette}</HighlightColorSetting>
 							</FormRow>


### PR DESCRIPTION
When viewing settings > theme, opening the highlight-color `ColorPicker` can result in the popup bleeding off-screen slightly (it's more apparent using the carbon theme).

The safest solution for the time being appears to be simply applying enough margin to the row to keep the popup in the viewport.