### PR TITLE
PLAT-71806: Adjust settings divider spacing

### DIFF
--- a/console/src/views/Settings.js
+++ b/console/src/views/Settings.js
@@ -51,7 +51,7 @@ const Settings = kind({
 							className={css.header}
 							component={Divider}
 							shrink
-							spacing="small"
+							spacing="none"
 						>
 							Settings
 						</Cell>


### PR DESCRIPTION
Adjusts the settings divider `spacing` prop to give the appearance of uniform height for settings items.