### PR TITLE
ENYO-5765: Fix URL parameter of pushState

### DIFF
--- a/console/src/index.js
+++ b/console/src/index.js
@@ -21,7 +21,7 @@ if (typeof window !== 'undefined') {
 		params.index = ev.index;
 		const stringified = qs.stringify(params);
 
-		window.history.pushState(ev, '', `/?${stringified}`);
+		window.history.pushState(ev, '', `?${stringified}`);
 	};
 
 	appElement = (


### PR DESCRIPTION
### Issue Resolved / Feature Added
- Images don't display properly on apps installed on TV.

### Resolution
- The images were referring to the wrong path. So I changed the path specification of pushState to refer to the normal path.

### Links
ENYO-5765

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)