### PR TITLE
PLAT-84500: Update other Agate apps to point to agate 1.0.0-alpha.0…

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -32,7 +32,7 @@
 		"dist/*"
 	],
 	"dependencies": {
-		"@enact/agate": "github:enactjs/agate#master",
+		"@enact/agate": "github:enactjs/agate#1.0.0-alpha.0",
 		"@enact/core": "^2.2.8",
 		"@enact/i18n": "^2.2.8",
 		"@enact/spotlight": "^2.2.8",

--- a/copilot/package.json
+++ b/copilot/package.json
@@ -31,7 +31,7 @@
 		"dist/*"
 	],
 	"dependencies": {
-		"@enact/agate": "github:enactjs/agate#master",
+		"@enact/agate": "github:enactjs/agate#1.0.0-alpha.0",
 		"@enact/core": "^2.2.8",
 		"@enact/i18n": "^2.2.8",
 		"@enact/ui": "^2.2.8",

--- a/kitchen-sink/package.json
+++ b/kitchen-sink/package.json
@@ -30,7 +30,7 @@
 		"dist/*"
 	],
 	"dependencies": {
-		"@enact/agate": "github:enactjs/agate#master",
+		"@enact/agate": "github:enactjs/agate#1.0.0-alpha.0",
 		"@enact/core": "^2.0.0",
 		"@enact/i18n": "^2.0.0",
 		"@enact/moonstone": "^2.0.0",


### PR DESCRIPTION
…instead of master.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>