### PR TITLE
PLAT-84599: Fix small->size prop and other prop bleed

### DIFF
--- a/console/src/components/DestinationList/DestinationList.js
+++ b/console/src/components/DestinationList/DestinationList.js
@@ -13,7 +13,7 @@ import css from './DestinationList.module.less';
 
 const DestinationButton = (props) => {
 	const {children, 'data-index': index, ...rest} = props;
-	return <Button small {...rest} css={css}>
+	return <Button size="small" {...rest} css={css}>
 		<Marker css={css}>{index + 1}</Marker>
 		{children}
 	</Button>;

--- a/console/src/components/MapController/MapController.js
+++ b/console/src/components/MapController/MapController.js
@@ -223,7 +223,7 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 									<Divider>Navigating To</Divider>
 									<Button
 										className={css.button}
-										small
+										size="small"
 										highlighted
 										disabled
 									>{description}</Button>
@@ -258,16 +258,18 @@ const MapControllerHoc = hoc((configHoc, Wrapped) => {
 								<Cell
 									shrink
 									className={css.columnCell}
-									component={ToggleButton}
-									css={css}
-									small
-									// We want to be able to factor in the autonomous state, but
-									// perhaps that needs to happen in ServiceLayer, and not here.
-									selected={destination && navigating}
-									onToggle={this.startNavigation}
-									toggleOnLabel="Stop Navigation"
-									toggleOffLabel="Start Navigation"
-								/>
+								>
+									<ToggleButton
+										css={css}
+										size="small"
+										// We want to be able to factor in the autonomous state, but
+										// perhaps that needs to happen in ServiceLayer, and not here.
+										selected={destination && navigating}
+										onToggle={this.startNavigation}
+										toggleOnLabel="Stop Navigation"
+										toggleOffLabel="Start Navigation"
+									/>
+								</Cell>
 							}
 						</Column>
 					</tools>

--- a/console/src/components/ProfileDrawer/ProfileDrawer.js
+++ b/console/src/components/ProfileDrawer/ProfileDrawer.js
@@ -143,16 +143,18 @@ const ProfileDrawerBase = kind({
 								<Cell
 									style={{margin: '0.25em 1em 1em'}}
 									align="stretch"
-									component={ToggleButtonBase}
-									onClick={layoutArrangeableToggle}
-									selected={layoutArrangeable}
-									shrink
-									small
-									toggleOffLabel="Edit Layout"
-									toggleOnLabel="Done"
-									type="grid"
-									underline
-								/>
+								>
+									<ToggleButtonBase
+										onClick={layoutArrangeableToggle}
+										selected={layoutArrangeable}
+										shrink
+										size="small"
+										toggleOffLabel="Edit Layout"
+										toggleOnLabel="Done"
+										type="grid"
+										underline
+									/>
+								</Cell>
 							</Column>
 						</afterTabs>
 					</TabGroup>

--- a/console/src/components/UserSelectionPopup/UserSelectionPopup.js
+++ b/console/src/components/UserSelectionPopup/UserSelectionPopup.js
@@ -116,9 +116,15 @@ const UserSelectionPopupBase = kind({
 
 				<buttons>
 					<Row align="center space-around">
-						<Cell shrink component={Button} small className={css.button} onClick={resetUserSettings}>Reset Current User</Cell>
-						<Cell shrink component={Button} small className={css.button} onClick={onResetAll}>Restart Demo</Cell>
-						<Cell shrink component={Button} small className={css.button} onClick={onResetPosition}>Reset Position</Cell>
+						<Cell shrink>
+							<Button className={css.button} size="small" onClick={resetUserSettings}>Reset Current User</Button>
+						</Cell>
+						<Cell shrink>
+							<Button className={css.button} size="small" onClick={onResetAll}>Restart Demo</Button>
+						</Cell>
+						<Cell shrink>
+							<Button className={css.button} size="small" onClick={onResetPosition}>Reset Position</Button>
+						</Cell>
 					</Row>
 				</buttons>
 			</Popup>

--- a/console/src/views/Radio.js
+++ b/console/src/views/Radio.js
@@ -138,8 +138,8 @@ const RadioBase = kind({
 						<Row align="center space-around" wrap className={css.info}>
 							{/* Band Selector */}
 							<Cell shrink className={css.radioToggle}>
-								<ToggleButton onClick={onBandToggle} selected={band === 'AM'} small type="grid">AM</ToggleButton>|
-								<ToggleButton onClick={onBandToggle} selected={band === 'FM'} small type="grid">FM</ToggleButton>
+								<ToggleButton onClick={onBandToggle} selected={band === 'AM'} size="small" type="grid">AM</ToggleButton>|
+								<ToggleButton onClick={onBandToggle} selected={band === 'FM'} size="small" type="grid">FM</ToggleButton>
 							</Cell>
 							{/* Station Info */}
 							<Cell shrink className={css.title}>

--- a/sampler/stories/default/Button.js
+++ b/sampler/stories/default/Button.js
@@ -29,7 +29,7 @@ storiesOf('Agate', module)
 				icon={select('icon', prop.icons, Config)}
 				joinedPosition={select('joinedPosition', prop.joinedPosition, Config)}
 				selected={boolean('selected', Config)}
-				small={boolean('small', Config)}
+				size={select('size', ['small', 'large'], Config)}
 				type={select('type', ['standard', 'grid'], Config)}
 			>
 				{text('children', Button, 'Click me')}

--- a/sampler/stories/default/Icon.js
+++ b/sampler/stories/default/Icon.js
@@ -1,34 +1,39 @@
-import Icon from '@enact/agate/Icon';
+import Icon, {IconBase} from '@enact/agate/Icon';
 import Divider from '@enact/agate/Divider';
+import UiIcon from '@enact/ui/Icon';
+import Scroller from '@enact/ui/Scroller';
 import iconNames from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
-import {boolean, select, text} from '../../src/enact-knobs';
+import {select, text} from '../../src/enact-knobs';
 import emptify from '../../src/utils/emptify.js';
+import {mergeComponentMetadata} from '../../src/utils';
 
 // import icons
 import docs from '../../images/icon-enact-docs.png';
 import factory from '../../images/icon-enact-factory.svg';
 import logo from '../../images/icon-enact-logo.svg';
 
+const Config = mergeComponentMetadata('Icon', UiIcon, IconBase, Icon);
+
 storiesOf('Agate', module)
 	.add(
 		'Icon',
 		() => {
-			const small = boolean('small', Icon);
+			const size = select('size', ['small', 'large'], Config, 'large');
 			return (
-				<div>
+				<Scroller style={{height: '100%'}}>
 					<Icon
-						small={small}
+						size={size}
 					>
 						{emptify(select('src', ['', docs, factory, logo], Icon, '')) + emptify(select('icon', ['', ...iconNames], Icon, 'home')) + emptify(text('custom icon', Icon, ''))}
 					</Icon>
 					<br />
 					<br />
 					<Divider>All Icons</Divider>
-					{iconNames.map((icon, index) => <Icon key={index} small={small} title={icon}>{icon}</Icon>)}
-				</div>
+					{iconNames.map((icon, index) => <Icon key={index} size={size} title={icon}>{icon}</Icon>)}
+				</Scroller>
 			);
 		},
 		{

--- a/sampler/stories/default/IconButton.js
+++ b/sampler/stories/default/IconButton.js
@@ -27,8 +27,7 @@ storiesOf('Agate', module)
 				disabled={boolean('disabled', Config)}
 				highlighted={boolean('highlighted', Config)}
 				selected={boolean('selected', Config)}
-				small={boolean('small', Config)}
-				size={select('size', [null, 'small', 'smallest'], Config)}
+				size={select('size', ['smallest', 'small', 'large'], Config)}
 				type={select('type', ['standard', 'grid'], Config)}
 			>
 				{select('children', prop.icons, Config, 'home')}

--- a/sampler/stories/default/Input.js
+++ b/sampler/stories/default/Input.js
@@ -24,7 +24,7 @@ storiesOf('Agate', module)
 				invalid={boolean('invalid', Config)}
 				invalidMessage={text('invalidMessage', Config)}
 				placeholder={text('placeholder', Config, 'Input text here')}
-				small={boolean('small', Config)}
+				size={select('size', ['small', 'large'], Config)}
 				type={text('type', Config)}
 				defaultValue=""
 			/>

--- a/sampler/stories/default/LabeledIcon.js
+++ b/sampler/stories/default/LabeledIcon.js
@@ -1,10 +1,16 @@
+import Icon, {IconBase} from '@enact/agate/Icon';
 import LabeledIcon from '@enact/agate/LabeledIcon';
+import UiIcon from '@enact/ui/Icon';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import iconNames from './icons';
 import {boolean, text, select} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
 LabeledIcon.displayName = 'LabeledIcon';
+
+const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, UiIcon, IconBase, Icon, LabeledIcon);
 
 storiesOf('Agate', module)
 	.add(
@@ -13,6 +19,7 @@ storiesOf('Agate', module)
 			<LabeledIcon
 				icon={select('icon', ['', ...iconNames], LabeledIcon, 'temperature')}
 				disabled={boolean('disabled', LabeledIcon)}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{text('children', LabeledIcon, 'Hello LabeledIcon')}
 			</LabeledIcon>

--- a/sampler/stories/default/LabeledIconButton.js
+++ b/sampler/stories/default/LabeledIconButton.js
@@ -20,7 +20,7 @@ storiesOf('Agate', module)
 				inline={boolean('inline', Config)}
 				labelPosition={select('labelPosition', ['above', 'after', 'before', 'below', 'left', 'right'], Config)}
 				selected={boolean('selected', Config)}
-				small={boolean('small', Config)}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{text('children', Config, 'Hello LabeledIconButton')}
 			</LabeledIconButton>

--- a/sampler/stories/default/ProgressBar.js
+++ b/sampler/stories/default/ProgressBar.js
@@ -15,10 +15,9 @@ storiesOf('Agate', module)
 		() => (
 			<ProgressBar
 				disabled={boolean('disabled', Config)}
-				focused={boolean('focused', Config)}
-				small={boolean('small', Config)}
 				orientation={select('orientation', ['horizontal', 'vertical'], Config)}
 				progress={number('progress', Config, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
+				size={select('size', ['small', 'large'], Config)}
 			/>
 		),
 		{

--- a/sampler/stories/default/TabbedPanels.js
+++ b/sampler/stories/default/TabbedPanels.js
@@ -27,10 +27,10 @@ storiesOf('Agate', module)
 				]}
 			>
 				<beforeTabs>
-					<Button small type="grid" icon="arrowhookleft" />
+					<Button size="small" type="grid" icon="arrowhookleft" />
 				</beforeTabs>
 				<afterTabs>
-					<Button small type="grid" icon="arrowhookright" />
+					<Button size="small" type="grid" icon="arrowhookright" />
 				</afterTabs>
 				<Panel>
 					<Button icon="fullscreen">Click me!</Button>

--- a/sampler/stories/default/ToggleButton.js
+++ b/sampler/stories/default/ToggleButton.js
@@ -1,5 +1,6 @@
+import Button, {ButtonBase} from '@enact/agate/Button';
 import ToggleButton, {ToggleButtonBase} from '@enact/agate/ToggleButton';
-import UiButton from '@enact/ui/Button';
+import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
@@ -9,7 +10,7 @@ import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
 ToggleButton.displayName = 'ToggleButton';
-const Config = mergeComponentMetadata('ToggleButton', UiButton, ToggleButtonBase, ToggleButton);
+const Config = mergeComponentMetadata('ToggleButton', UIButtonBase, UIButton, ButtonBase, Button, ToggleButtonBase, ToggleButton);
 
 // Set up some defaults for info and knobs
 const prop = {
@@ -24,7 +25,7 @@ storiesOf('Agate', module)
 				onClick={action('onClick')}
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}
-				small={boolean('small', Config)}
+				size={select('size', ['small', 'large'], Config)}
 				onToggle={action('onToggle')}
 				underline={boolean('underline', Config, true)}
 				toggleOffLabel={text('toggleOffLabel', Config, 'Off')}


### PR DESCRIPTION
Updating apps (console and sampler) to use `size` prop vs deprecated `small` prop for appropriate components.