### PR TITLE
PLAT-86660: agate/Popup should forward to `onClose` when the close button is tapped/clicked

### DIFF
--- a/sampler/stories/default/Popup.js
+++ b/sampler/stories/default/Popup.js
@@ -18,7 +18,6 @@ storiesOf('Agate', module)
 					open={boolean('open', Config)}
 					noAnimation={boolean('noAnimation', Config)}
 					noAutoDismiss={boolean('noAutoDismiss', Config)}
-					onCloseButtonClick={action('onCloseButtonClick')}
 					onClose={action('onClose')}
 					onHide={action('onHide')}
 					scrimType={select('scrimType', ['none', 'translucent', 'transparent'], Config, 'translucent')}


### PR DESCRIPTION
This patch updates the `agate/Popup` sample to use `onClose` because we've removed `onCloseButtonClick`.