### PR TITLE
ENYO-6394: Add "show all skins" global knob

### DIFF
--- a/sampler/src/AgateEnvironment/AgateEnvironment.js
+++ b/sampler/src/AgateEnvironment/AgateEnvironment.js
@@ -4,10 +4,12 @@ import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {color} from '@storybook/addon-knobs';
-import {Column, Cell} from '@enact/ui/Layout';
+import {Row, Column, Cell} from '@enact/ui/Layout';
 import AgateDecorator from '@enact/agate/AgateDecorator';
 import Heading from '@enact/agate/Heading';
 import {Panels, Panel} from '@enact/agate/Panels';
+import Skinnable from '@enact/agate/Skinnable';
+import Scroller from '@enact/agate/Scroller';
 import {boolean, select} from '../enact-knobs';
 
 import css from './AgateEnvironment.module.less';
@@ -18,6 +20,8 @@ const globalGroup = 'Global Knobs';
 // 	const {protocol, host, pathname} = window.parent.location;
 // 	window.parent.location.href = protocol + '//' + host + pathname;
 // };
+
+const SkinFrame = Skinnable((props) => <Row {...props} style={{...props.style, marginBottom: '2em'}} />);
 
 const PanelsBase = kind({
 	name: 'AgateEnvironment',
@@ -134,6 +138,7 @@ const StorybookDecorator = (story, config) => {
 	memory.skin = currentSkin;  // Remember the skin for the next time we load.
 	const accentFromURL = getPropFromURL('accent');
 	const highlightFromURL = getPropFromURL('highlight');
+	const allSkins = boolean('show all skins', Config);
 
 	return (
 		<Agate
@@ -144,7 +149,14 @@ const StorybookDecorator = (story, config) => {
 			accent={color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)}
 			highlight={color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)}
 		>
-			{sample}
+			<Scroller>
+				{allSkins ? Object.keys(skins).map(skin => (
+					<SkinFrame skin={skins[skin]} key={skin}>
+						<Cell size="20%" component={Heading}>{skin}</Cell>
+						<Cell>{sample}</Cell>
+					</SkinFrame>
+				)) : sample}
+			</Scroller>
 		</Agate>
 	);
 };

--- a/sampler/src/AgateEnvironment/AgateEnvironment.js
+++ b/sampler/src/AgateEnvironment/AgateEnvironment.js
@@ -21,7 +21,16 @@ const globalGroup = 'Global Knobs';
 // 	window.parent.location.href = protocol + '//' + host + pathname;
 // };
 
-const SkinFrame = Skinnable((props) => <Row {...props} style={{...props.style, marginBottom: '2em'}} />);
+const SkinFrame = Skinnable(kind({
+	name: 'SkinFrame',
+	styles: {
+		css,
+		className: 'skinFrame'
+	},
+	render: (props) => (
+		<Row {...props} />
+	)
+}));
 
 const PanelsBase = kind({
 	name: 'AgateEnvironment',
@@ -102,6 +111,7 @@ const StorybookDecorator = (story, config) => {
 	const sample = story();
 	const Config = {
 		defaultProps: {
+			'night mode': false,
 			skin: 'gallium'
 		},
 		groupId: globalGroup
@@ -133,19 +143,23 @@ const StorybookDecorator = (story, config) => {
 		}
 	};
 	const skinFromURL = getPropFromURL('skin');
-	const currentSkin = skinFromURL ? skinFromURL : 'gallium';
+	const currentSkin = skinFromURL ? skinFromURL : Config.defaultProps.skin;
 	const newSkin = (memory.skin !== currentSkin);
 	memory.skin = currentSkin;  // Remember the skin for the next time we load.
 	const accentFromURL = getPropFromURL('accent');
 	const highlightFromURL = getPropFromURL('highlight');
 	const allSkins = boolean('show all skins', Config);
+	const skinKnobs = {};
+	if (!allSkins) {
+		skinKnobs.skin = select('skin', skins, Config, currentSkin);
+	}
 
 	return (
 		<Agate
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
-			skin={select('skin', skins, Config, currentSkin)}
-			skinVariants={boolean('Night Mode', Config, false) && 'night'}
+			{...skinKnobs}
+			skinVariants={boolean('night mode', Config) && 'night'}
 			accent={color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)}
 			highlight={color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)}
 		>

--- a/sampler/src/AgateEnvironment/AgateEnvironment.module.less
+++ b/sampler/src/AgateEnvironment/AgateEnvironment.module.less
@@ -1,7 +1,27 @@
-// // AgateEnvironment.module.less
-// //
-// @import "~@enact/moonstone/styles/variables.less";
+// AgateEnvironment.module.less
 //
+@import "~@enact/agate/styles/mixins.less";
+@import "~@enact/agate/styles/skin.less";
+
+.skinFrame {
+	padding: 1em;
+	position: relative;
+
+	.applySkins({
+		// These background rules, and the &::before below are cloned from AgateDecorator to mimic the style an app gets.
+		background-color: @agate-bg-color;
+		background-image: @agate-bg-image;
+
+		&::before {
+			content: "";
+			display: block;
+			background-image: @agate-bg-image2;
+			position: absolute;
+			.position(0);
+		}
+	});
+}
+
 // // from ~@enact/ui/styles/core.less. Can't import global mixins.
 // .enact-selectable() {
 // 	cursor: auto;

--- a/sampler/stories/default/TabbedPanels.js
+++ b/sampler/stories/default/TabbedPanels.js
@@ -11,49 +11,53 @@ import {boolean, select} from '../../src/enact-knobs';
 
 TabbedPanels.displayName = 'TabbedPanels';
 
+// `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.
+
 storiesOf('Agate', module)
 	.add(
 		'TabbedPanels',
 		() => (
-			<TabbedPanels
-				onClick={action('onClick')}
-				index={Number(select('index', ['0', '1', '2', '3'], TabbedPanels, '0'))}
-				noCloseButton={boolean('noCloseButton', TabbedPanels)}
-				onSelect={action('onSelect')}
-				orientation={select('orientation', ['vertical', 'horizontal'], TabbedPanels, 'vertical')}
-				tabPosition={select('tabPosition', ['before', 'after'], TabbedPanels, 'before')}
-				tabs={[
-					{title: 'Button', icon: 'netbook'},
-					{title: 'Item', icon: 'aircirculation'},
-					{title: 'LabeledIconButton', icon: 'temperature'}
-				]}
-			>
-				<beforeTabs>
-					<Button size="small" type="grid" icon="arrowlargeleft" />
-				</beforeTabs>
-				<afterTabs>
-					<Button size="small" type="grid" icon="arrowlargeright" />
-				</afterTabs>
-				<Panel>
-					<Button icon="netbook">Click me!</Button>
-				</Panel>
-				<Panel>
-					<Item label="label" labelPosition="before" slotBefore={<Icon>aircirculation</Icon>}>Hello Item</Item>
-				</Panel>
-				<Panel className="enact-fit">
-					<LabeledIconButton
-						labelPosition="after"
-						icon="temperature"
-					>
-						Hello LabeledIconButton
-					</LabeledIconButton>
-				</Panel>
-				<Panel>
-					<div>
-						A simple view with no associated tab
-					</div>
-				</Panel>
-			</TabbedPanels>
+			<div style={{paddingBottom: '56.25%'}}>
+				<TabbedPanels
+					onClick={action('onClick')}
+					index={Number(select('index', ['0', '1', '2', '3'], TabbedPanels, '0'))}
+					noCloseButton={boolean('noCloseButton', TabbedPanels)}
+					onSelect={action('onSelect')}
+					orientation={select('orientation', ['vertical', 'horizontal'], TabbedPanels, 'vertical')}
+					tabPosition={select('tabPosition', ['before', 'after'], TabbedPanels, 'before')}
+					tabs={[
+						{title: 'Button', icon: 'netbook'},
+						{title: 'Item', icon: 'aircirculation'},
+						{title: 'LabeledIconButton', icon: 'temperature'}
+					]}
+				>
+					<beforeTabs>
+						<Button size="small" type="grid" icon="arrowlargeleft" />
+					</beforeTabs>
+					<afterTabs>
+						<Button size="small" type="grid" icon="arrowlargeright" />
+					</afterTabs>
+					<Panel>
+						<Button icon="netbook">Click me!</Button>
+					</Panel>
+					<Panel>
+						<Item label="label" labelPosition="before" slotBefore={<Icon>aircirculation</Icon>}>Hello Item</Item>
+					</Panel>
+					<Panel className="enact-fit">
+						<LabeledIconButton
+							labelPosition="after"
+							icon="temperature"
+						>
+							Hello LabeledIconButton
+						</LabeledIconButton>
+					</Panel>
+					<Panel>
+						<div>
+							A simple view with no associated tab
+						</div>
+					</Panel>
+				</TabbedPanels>
+			</div>
 		),
 		{
 			text: 'The basic TabbedPanels'


### PR DESCRIPTION
With this fancy new knob, we have the option to view multiple skins at once on one screen. This should help a lot in an effort to maintain multiple visual styles at once.
<img width="1481" alt="Screen Shot 2020-01-03 at 6 28 50 PM" src="https://user-images.githubusercontent.com/386529/71758608-ec9d0500-2e56-11ea-8d17-2aca96a38f01.png">
<img width="1473" alt="Screen Shot 2020-01-03 at 6 26 28 PM" src="https://user-images.githubusercontent.com/386529/71758609-f0c92280-2e56-11ea-809b-7a8412f71254.png">

