### PR TITLE
WRP-8577: Fix Picker in climate page css issue

### DIFF
--- a/console/src/views/HVAC.js
+++ b/console/src/views/HVAC.js
@@ -130,6 +130,7 @@ const HvacBase = kind({
 					<Cell
 						className={css.picker}
 						component={Picker}
+						css={css}
 						onChange={onUpdateLeftTemperature}
 						orientation="vertical"
 						shrink
@@ -162,6 +163,7 @@ const HvacBase = kind({
 					<Cell
 						className={css.picker}
 						component={Picker}
+						css={css}
 						onChange={onUpdateRightTemperature}
 						orientation="vertical"
 						shrink

--- a/console/src/views/HVAC.js
+++ b/console/src/views/HVAC.js
@@ -130,7 +130,6 @@ const HvacBase = kind({
 					<Cell
 						className={css.picker}
 						component={Picker}
-						css={css}
 						onChange={onUpdateLeftTemperature}
 						orientation="vertical"
 						shrink
@@ -163,7 +162,6 @@ const HvacBase = kind({
 					<Cell
 						className={css.picker}
 						component={Picker}
-						css={css}
 						onChange={onUpdateRightTemperature}
 						orientation="vertical"
 						shrink

--- a/console/src/views/HVAC.module.less
+++ b/console/src/views/HVAC.module.less
@@ -1,9 +1,12 @@
+@import '~@enact/agate/styles/mixins.less';
+@import '~@enact/agate/styles/skin.less';
+
 .hvac {
 	padding: 24px;
 
-	.picker, .button {
-		min-width: 159px;
+	.button {
 		display: block;
+		min-width: 159px;
 	}
 
 	.stackedButtons .button {
@@ -28,4 +31,10 @@
 		margin-top: 12px;
 		margin-bottom: 12px;
 	}
+}
+
+.picker {
+	.applySkins({
+		min-width: 159px;
+	})
 }


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Picker in Climate page was broken on focus, on Silicon skin (The increment/decrement values were not visible).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed Picker by overwriting the HVAC css file.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-8577

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com