### PR TITLE
WRP-8569:  Add agate/MediaPlayer in CompactMusic

### DIFF
--- a/console/src/components/CompactMusic/CompactMusic.js
+++ b/console/src/components/CompactMusic/CompactMusic.js
@@ -1,10 +1,8 @@
 // import Button from '@enact/agate/Button';
-// import ImageItem from '@enact/agate/ImageItem';
-import MediaPlayer from '@enact/agate/MediaPlayer'
+import MediaPlayer from '@enact/agate/MediaPlayer';
 import kind from '@enact/core/kind';
 import {Cell} from '@enact/ui/Layout';
 
-// import albumArt from '../../../assets/music-album-art.jpg';
 import Widget from '../Widget';
 
 import css from './CompactMusic.module.less';
@@ -57,14 +55,7 @@ const CompactMusicBase = kind({
 		return (
 			<Widget {...props} icon="music" title="Listen" description="Listen to your favorite tunes" view="radio" align="center center">
 				<Cell shrink>
-					<MediaPlayer
-						// caption="The Title"
-						// className={css.album}
-						// css={css}
-						// selectionOverlayShowing
-						type="tiny"
-						// subCaption="The Album"
-					>{source}</MediaPlayer>
+					<MediaPlayer type="tiny">{source}</MediaPlayer>
 				</Cell>
 			</Widget>
 		);

--- a/console/src/components/CompactMusic/CompactMusic.js
+++ b/console/src/components/CompactMusic/CompactMusic.js
@@ -1,4 +1,3 @@
-// import Button from '@enact/agate/Button';
 import MediaPlayer from '@enact/agate/MediaPlayer';
 import kind from '@enact/core/kind';
 import {Cell} from '@enact/ui/Layout';
@@ -6,31 +5,6 @@ import {Cell} from '@enact/ui/Layout';
 import Widget from '../Widget';
 
 import css from './CompactMusic.module.less';
-
-// const PlaybackControls = kind({
-// 	name: 'PlaybackControls',
-//
-// 	styles: {
-// 		css,
-// 		className: 'playbackControls'
-// 	},
-//
-// 	render: (props) => {
-// 		return (
-// 			<Row {...props} align="center center">
-// 				<Cell shrink>
-// 					<Button size="small" icon="arrowlargeleft" />
-// 				</Cell>
-// 				<Cell shrink>
-// 					<Button size="small" icon="ellipsis" />
-// 				</Cell>
-// 				<Cell shrink>
-// 					<Button size="small" icon="arrowlargeright" />
-// 				</Cell>
-// 			</Row>
-// 		);
-// 	}
-// });
 
 const CompactMusicBase = kind({
 	name: 'CompactMusic',
@@ -53,7 +27,7 @@ const CompactMusicBase = kind({
 		const source = audioFiles.map((audioFile, index) => (<source key={index} src={audioFile} type="audio/mp3" />));
 
 		return (
-			<Widget {...props} icon="music" title="Listen" description="Listen to your favorite tunes" view="radio" align="center center">
+			<Widget {...props} align="center center" description="Listen to your favorite tunes" icon="music" title="Listen" view="radio">
 				<Cell shrink>
 					<MediaPlayer type="tiny">{source}</MediaPlayer>
 				</Cell>
@@ -64,6 +38,5 @@ const CompactMusicBase = kind({
 
 export default CompactMusicBase;
 export {
-	CompactMusicBase as CompactMusic,
 	CompactMusicBase
 };

--- a/console/src/components/CompactMusic/CompactMusic.js
+++ b/console/src/components/CompactMusic/CompactMusic.js
@@ -1,9 +1,10 @@
 // import Button from '@enact/agate/Button';
-import ImageItem from '@enact/agate/ImageItem';
+// import ImageItem from '@enact/agate/ImageItem';
+import MediaPlayer from '@enact/agate/MediaPlayer'
 import kind from '@enact/core/kind';
 import {Cell} from '@enact/ui/Layout';
 
-import albumArt from '../../../assets/music-album-art.jpg';
+// import albumArt from '../../../assets/music-album-art.jpg';
 import Widget from '../Widget';
 
 import css from './CompactMusic.module.less';
@@ -42,17 +43,28 @@ const CompactMusicBase = kind({
 	},
 
 	render: (props) => {
+		const audioFiles = [
+			'https://sampleswap.org/mp3/artist/254731/BossPlayer_Your-Right-Here-160.mp3',
+			'https://sampleswap.org/mp3/artist/78152/HiatusManJBanner_Show-Stopper-160.mp3',
+			'https://sampleswap.org/mp3/artist/47067/DJ-Masque_Oceanic-Dawn-160.mp3',
+			'https://sampleswap.org/mp3/artist/26546/benzoul_lovevoodoo-160.mp3',
+			'https://sampleswap.org/mp3/artist/19139/MarkNine_In-my-Place-160.mp3',
+			'https://sampleswap.org/mp3/artist/47067/DJ-Masque_Dont-Forget-To-Be-Yourself-160.mp3'
+		];
+
+		const source = audioFiles.map((audioFile, index) => (<source key={index} src={audioFile} type="audio/mp3" />));
+
 		return (
 			<Widget {...props} icon="music" title="Listen" description="Listen to your favorite tunes" view="radio" align="center center">
 				<Cell shrink>
-					<ImageItem
-						caption="The Title"
-						css={css}
-						className={css.album}
-						selectionOverlayShowing
-						src={albumArt}
-						subCaption="The Album"
-					/>
+					<MediaPlayer
+						// caption="The Title"
+						// className={css.album}
+						// css={css}
+						// selectionOverlayShowing
+						type="tiny"
+						// subCaption="The Album"
+					>{source}</MediaPlayer>
 				</Cell>
 			</Widget>
 		);

--- a/console/src/components/CompactMusic/CompactMusic.module.less
+++ b/console/src/components/CompactMusic/CompactMusic.module.less
@@ -1,13 +1,3 @@
-//.compactMusic {
-//	.album {
-//		width: 207px;
-//
-//		.caption {
-//			margin-top: 12px;
-//		}
-//	}
-//
-//	.playbackControls {
-//		pointer-events: auto;
-//	}
-//}
+.compactMusic {
+	// styles can be put here
+}

--- a/console/src/components/CompactMusic/CompactMusic.module.less
+++ b/console/src/components/CompactMusic/CompactMusic.module.less
@@ -1,13 +1,13 @@
-.compactMusic {
-	.album {
-		width: 207px;
-	
-		.caption {
-			margin-top: 12px;
-		}
-	}
-
-	.playbackControls {
-		pointer-events: auto;
-	}
-}
+//.compactMusic {
+//	.album {
+//		width: 207px;
+//
+//		.caption {
+//			margin-top: 12px;
+//		}
+//	}
+//
+//	.playbackControls {
+//		pointer-events: auto;
+//	}
+//}

--- a/console/src/views/Home.js
+++ b/console/src/views/Home.js
@@ -217,9 +217,9 @@ const Home = kind({
 			<HomeLayout arrangeable={arrangeable}>
 				<tray1><CompactHvac onExpand={onCompactExpand} /></tray1>
 				<tray2><CompactAppList onExpand={onCompactExpand} onSelect={onSelect} /></tray2>
-				<tray3><CompactMusic onExpand={onCompactExpand} /></tray3>
+				<tray3><CompactWeather onExpand={onCompactExpand} /></tray3>
 
-				<small1><CompactWeather onExpand={onCompactExpand} /></small1>
+				<small1><CompactMusic onExpand={onCompactExpand} /></small1>
 				<small2><CompactScreenMonitor onExpand={onCompactExpand} /></small2>
 				<medium><CompactMultimedia onExpand={onCompactExpand} onSendVideo={onSendVideo} screenIds={[1]} /></medium>
 				<large><CompactMap onExpand={onCompactExpand} /></large>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ImageItem component was used inside CompactMusic. This version was using GridListImageItem with some buttons overlayed which was mocking a media player.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added MediaPlayer to CompactMusic. Now Agate has a working component for rendering media.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-8569

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com