### PR TITLE
WRP-10546: Added functionality to restore manually set accent/highlight colors

### DIFF
--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -403,7 +403,7 @@ const AppDecorator = compose(
 	ServiceLayer,
 	AppContextConnect(({appState, userSettings, userId, updateAppState}) => ({
 		accent: userSettings.colorAccent,
-		dynamicColor: userSettings.dynamicColor,
+		//dynamicColor: userSettings.dynamicColor,
 		highlight: userSettings.colorHighlight,
 		layoutArrangeable: userSettings.arrangements.arrangeable,
 		orientation: (userSettings.skin !== 'carbon') ? 'horizontal' : 'vertical',

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -1,3 +1,4 @@
+import CheckboxItem from '@enact/agate/CheckboxItem';
 import ColorPicker from '@enact/agate/ColorPicker';
 import Heading from '@enact/agate/Heading';
 import LabeledIconButton from '@enact/agate/LabeledIconButton';
@@ -201,12 +202,9 @@ const ThemeSettingsBase = (props) => {
 							</FontSizeSetting>
 						</Cell>*/}
 						<Cell shrink className={componentCss.spacedItem}>
-							<DynamicColorSetting
-								label="Dynamic color change"
-								onSendSkinSettings={onSendSkinSettings}
-							>
-								{['false', 'true']}
-							</DynamicColorSetting>
+							<DynamicColorSetting2>
+								Dynamic color change
+							</DynamicColorSetting2>
 						</Cell>
 					</Column>
 				</Cell>
@@ -227,6 +225,19 @@ ThemeSettingsBase.propTypes = {
 
 ThemeSettingsBase.displayName = 'ThemeSettings';
 
+const ColorCheckboxItem = kind({
+	name: 'ColorCheckboxItem',
+	styles: {
+		css: componentCss,
+		className: 'colorCheckboxItemRow'
+	},
+	render: ({...rest}) => (
+		<FormRow>
+			<Cell><CheckboxItem {...rest} /></Cell>
+		</FormRow>
+	)
+});
+
 const DynamicColorSetting = AppContextConnect(({userSettings, updateAppState}) => ({
 	value: userSettings.dynamicColor,
 	onChange: ({value}) => {
@@ -235,6 +246,16 @@ const DynamicColorSetting = AppContextConnect(({userSettings, updateAppState}) =
 		});
 	}
 }))(SliderButtonItem);
+
+const DynamicColorSetting2 = AppContextConnect(({userSettings, updateAppState}) => ({
+	selected: userSettings.dynamicColor,
+	onToggle: ({selected}) => {
+		console.log('aici dynamic color', selected)
+		updateAppState((state) => {
+			state.userSettings.dynamicColor = selected;
+		});
+	}
+}))(ColorCheckboxItem);
 
 // Example to show how to optimize rerenders.
 const SaveableSettings = (settingName, propName = 'value') => AppContextConnect(({userSettings, updateAppState}) => ({

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -102,8 +102,10 @@ const SliderButtonItem = kind({
 });
 
 const ThemeSettingsBase = (props) => {
-	const {onSendSkinSettings, prevIndex, ... rest} = props;
+	const {prevIndex, ... rest} = props;
 	const context = useContext(AppContext);
+
+	delete rest.onSendSkinSettings;
 
 	const handleSelect = useCallback((ev, {onSelect}) => {
 		onSelect({index: parseInt(ev.currentTarget.dataset.tabindex)});
@@ -117,6 +119,11 @@ const ThemeSettingsBase = (props) => {
 		let changeAccentColor, changeHighlightColor;
 
 		if (context.userSettings.dynamicColor) {
+			context.updateAppState((state) => {
+				state.userSettings.colorAccentManual = state.userSettings.colorAccent;
+				state.userSettings.colorHighlightManual = state.userSettings.colorHighlight;
+			});
+
 			changeAccentColor = setInterval(function () {
 				document.body.style.backgroundColor = 'hsl(' + indexAccent + ', 100%, 50%)';
 				let RGBColors = document.body.style.backgroundColor.match(/\d+/g);
@@ -144,11 +151,18 @@ const ThemeSettingsBase = (props) => {
 
 				indexHighlight++;
 			}, 100);
+		} else if (!context.userSettings.dynamicColor) {
+
+			context.updateAppState((state) => {
+				state.userSettings.colorAccent = context.userSettings.colorAccentManual;
+				state.userSettings.colorHighlight = context.userSettings.colorHighlightManual;
+			});
 		}
 
 		return () => {
 			clearInterval(changeAccentColor);
 			clearInterval(changeHighlightColor);
+
 			indexAccent = 0;
 			indexHighlight = 1000;
 		};
@@ -182,17 +196,17 @@ const ThemeSettingsBase = (props) => {
 						</Cell>
 						<Cell shrink className={componentCss.spacedItem}>
 							<FormRow align="start space-around" alignLabel="center" className={componentCss.formRow}>
-								<AccentColorSetting label="Accent Color" onClick={onChange} onSendSkinSettings={onSendSkinSettings}>{swatchPalette}</AccentColorSetting>
-								<HighlightColorSetting label="Highlight Color" onClick={onChange} onSendSkinSettings={onSendSkinSettings}>{swatchPalette}</HighlightColorSetting>
+								<AccentColorSetting disabled={context.userSettings.dynamicColor} label="Accent Color" onClick={onChange}>{swatchPalette}</AccentColorSetting>
+								<HighlightColorSetting disabled={context.userSettings.dynamicColor} label="Highlight Color" onClick={onChange}>{swatchPalette}</HighlightColorSetting>
 							</FormRow>
 						</Cell>
 						<Cell shrink className={componentCss.spacedItem}>
-							<SkinSetting label="Skin:" onClick={onChange} onSendSkinSettings={onSendSkinSettings}>
+							<SkinSetting label="Skin:" onClick={onChange}>
 								{skinNames}
 							</SkinSetting>
 						</Cell>
 						<Cell shrink className={componentCss.spacedItem}>
-							<SkinVariantsSetting label="Variant:" onClick={onChange} onSendSkinSettings={onSendSkinSettings}>
+							<SkinVariantsSetting disabled={context.userSettings.dynamicColor} label="Variant:" onClick={onChange}>
 								{skinVariantsNames}
 							</SkinVariantsSetting>
 						</Cell>
@@ -202,9 +216,9 @@ const ThemeSettingsBase = (props) => {
 							</FontSizeSetting>
 						</Cell>*/}
 						<Cell shrink className={componentCss.spacedItem}>
-							<DynamicColorSetting2>
+							<DynamicColorSetting>
 								Dynamic color change
-							</DynamicColorSetting2>
+							</DynamicColorSetting>
 						</Cell>
 					</Column>
 				</Cell>
@@ -227,10 +241,12 @@ ThemeSettingsBase.displayName = 'ThemeSettings';
 
 const ColorCheckboxItem = kind({
 	name: 'ColorCheckboxItem',
+
 	styles: {
 		css: componentCss,
-		className: 'colorCheckboxItemRow'
+		className: 'colorCheckboxItem'
 	},
+
 	render: ({...rest}) => (
 		<FormRow>
 			<Cell><CheckboxItem {...rest} /></Cell>
@@ -239,18 +255,8 @@ const ColorCheckboxItem = kind({
 });
 
 const DynamicColorSetting = AppContextConnect(({userSettings, updateAppState}) => ({
-	value: userSettings.dynamicColor,
-	onChange: ({value}) => {
-		updateAppState((state) => {
-			state.userSettings.dynamicColor = value;
-		});
-	}
-}))(SliderButtonItem);
-
-const DynamicColorSetting2 = AppContextConnect(({userSettings, updateAppState}) => ({
 	selected: userSettings.dynamicColor,
 	onToggle: ({selected}) => {
-		console.log('aici dynamic color', selected)
 		updateAppState((state) => {
 			state.userSettings.dynamicColor = selected;
 		});

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -304,7 +304,7 @@ const SkinVariantsSetting = AppContextConnect(({userSettings, updateAppState}) =
 const ThemeSettingsDecorator = compose(
 	AppContextConnect(({userSettings}) => ({
 		accent: userSettings.colorAccent,
-		dynamicColor: userSettings.dynamicColor,
+		//dynamicColor: userSettings.dynamicColor,
 		highlight: userSettings.colorHighlight,
 		skin: userSettings.skin,
 		skinVariants: userSettings.skinVariants

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -151,8 +151,7 @@ const ThemeSettingsBase = (props) => {
 
 				indexHighlight++;
 			}, 100);
-		} else if (!context.userSettings.dynamicColor) {
-
+		} else {
 			context.updateAppState((state) => {
 				state.userSettings.colorAccent = context.userSettings.colorAccentManual;
 				state.userSettings.colorHighlight = context.userSettings.colorHighlightManual;

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -101,11 +101,28 @@ const SliderButtonItem = kind({
 	)
 });
 
+const ColorCheckboxItem = kind({
+	name: 'ColorCheckboxItem',
+
+	styles: {
+		css: componentCss,
+		className: 'colorCheckboxItem'
+	},
+
+	render: ({...rest}) => (
+		<FormRow>
+			<Cell><CheckboxItem {...rest} /></Cell>
+		</FormRow>
+	)
+});
+
 const ThemeSettingsBase = (props) => {
 	const {prevIndex, ... rest} = props;
 	const context = useContext(AppContext);
 
 	delete rest.onSendSkinSettings;
+
+	const dynamicColorActive = context.userSettings.dynamicColor;
 
 	const handleSelect = useCallback((ev, {onSelect}) => {
 		onSelect({index: parseInt(ev.currentTarget.dataset.tabindex)});
@@ -118,7 +135,7 @@ const ThemeSettingsBase = (props) => {
 	useEffect (() => {
 		let changeAccentColor, changeHighlightColor;
 
-		if (context.userSettings.dynamicColor) {
+		if (dynamicColorActive) {
 			context.updateAppState((state) => {
 				state.userSettings.colorAccentManual = state.userSettings.colorAccent;
 				state.userSettings.colorHighlightManual = state.userSettings.colorHighlight;
@@ -195,8 +212,8 @@ const ThemeSettingsBase = (props) => {
 						</Cell>
 						<Cell shrink className={componentCss.spacedItem}>
 							<FormRow align="start space-around" alignLabel="center" className={componentCss.formRow}>
-								<AccentColorSetting disabled={context.userSettings.dynamicColor} label="Accent Color" onClick={onChange}>{swatchPalette}</AccentColorSetting>
-								<HighlightColorSetting disabled={context.userSettings.dynamicColor} label="Highlight Color" onClick={onChange}>{swatchPalette}</HighlightColorSetting>
+								<AccentColorSetting disabled={dynamicColorActive} label="Accent Color" onClick={onChange}>{swatchPalette}</AccentColorSetting>
+								<HighlightColorSetting disabled={dynamicColorActive} label="Highlight Color" onClick={onChange}>{swatchPalette}</HighlightColorSetting>
 							</FormRow>
 						</Cell>
 						<Cell shrink className={componentCss.spacedItem}>
@@ -205,7 +222,7 @@ const ThemeSettingsBase = (props) => {
 							</SkinSetting>
 						</Cell>
 						<Cell shrink className={componentCss.spacedItem}>
-							<SkinVariantsSetting disabled={context.userSettings.dynamicColor} label="Variant:" onClick={onChange}>
+							<SkinVariantsSetting disabled={dynamicColorActive} label="Variant:" onClick={onChange}>
 								{skinVariantsNames}
 							</SkinVariantsSetting>
 						</Cell>
@@ -237,30 +254,6 @@ ThemeSettingsBase.propTypes = {
 };
 
 ThemeSettingsBase.displayName = 'ThemeSettings';
-
-const ColorCheckboxItem = kind({
-	name: 'ColorCheckboxItem',
-
-	styles: {
-		css: componentCss,
-		className: 'colorCheckboxItem'
-	},
-
-	render: ({...rest}) => (
-		<FormRow>
-			<Cell><CheckboxItem {...rest} /></Cell>
-		</FormRow>
-	)
-});
-
-const DynamicColorSetting = AppContextConnect(({userSettings, updateAppState}) => ({
-	selected: userSettings.dynamicColor,
-	onToggle: ({selected}) => {
-		updateAppState((state) => {
-			state.userSettings.dynamicColor = selected;
-		});
-	}
-}))(ColorCheckboxItem);
 
 // Example to show how to optimize rerenders.
 const SaveableSettings = (settingName, propName = 'value') => AppContextConnect(({userSettings, updateAppState}) => ({
@@ -299,6 +292,15 @@ const SkinVariantsSetting = AppContextConnect(({userSettings, updateAppState}) =
 		});
 	}
 }))(SliderButtonItem);
+
+const DynamicColorSetting = AppContextConnect(({userSettings, updateAppState}) => ({
+	selected: userSettings.dynamicColor,
+	onToggle: ({selected}) => {
+		updateAppState((state) => {
+			state.userSettings.dynamicColor = selected;
+		});
+	}
+}))(ColorCheckboxItem);
 
 const ThemeSettingsDecorator = compose(
 	AppContextConnect(({userSettings}) => ({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Changed dynamic color control to CheckboxItem
Controls for accent/hightlight and skinVariant are disabled when dynamicColor is activated.
Added functionality to save manually set accent and highlight color when dynamicColor is activated and restoring them when dynamicColor is deactivated

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-10546

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)