### PR TITLE
WRP-13737: Layout adjustments

### DIFF
--- a/console/screenTypes.json
+++ b/console/screenTypes.json
@@ -1,10 +1,10 @@
 [
 	{"name": "pal",     "pxPerRem": 12, "width": 1024, "height": 576,  "aspectRatioName": "hdtv"},
 	{"name": "hd",      "pxPerRem": 16, "width": 1280, "height": 720,  "aspectRatioName": "hdtv"},
-	{"name": "mac",     "pxPerRem": 24, "width": 1680, "height": 1050, "aspectRatioName": "hdtv"},
+	{"name": "mac",     "pxPerRem": 24, "width": 1680, "height": 1050, "aspectRatioName": "hdtv", "base": true},
 	{"name": "fhd",     "pxPerRem": 24, "width": 1920, "height": 1080, "aspectRatioName": "hdtv"},
 	{"name": "uw-uxga", "pxPerRem": 24, "width": 2560, "height": 1080, "aspectRatioName": "cinema"},
 	{"name": "qhd",     "pxPerRem": 36, "width": 2560, "height": 1440, "aspectRatioName": "hdtv"},
-	{"name": "uhd",     "pxPerRem": 48, "width": 3840, "height": 2160, "aspectRatioName": "hdtv", "base": true},
+	{"name": "uhd",     "pxPerRem": 48, "width": 3840, "height": 2160, "aspectRatioName": "hdtv"},
 	{"name": "uhd2",    "pxPerRem": 96, "width": 7680, "height": 4320, "aspectRatioName": "hdtv"}
 ]

--- a/console/screenTypes.json
+++ b/console/screenTypes.json
@@ -1,10 +1,10 @@
 [
-	{"name": "pal",    "pxPerRem": 12, "width": 1024, "height": 576,  "aspectRatioName": "hdtv"},
+	{"name": "pal",     "pxPerRem": 12, "width": 1024, "height": 576,  "aspectRatioName": "hdtv"},
 	{"name": "hd",      "pxPerRem": 16, "width": 1280, "height": 720,  "aspectRatioName": "hdtv"},
+	{"name": "mac",     "pxPerRem": 36, "width": 1440, "height": 900,  "aspectRatioName": "hdtv"},
 	{"name": "fhd",     "pxPerRem": 24, "width": 1920, "height": 1080, "aspectRatioName": "hdtv"},
 	{"name": "uw-uxga", "pxPerRem": 24, "width": 2560, "height": 1080, "aspectRatioName": "cinema"},
 	{"name": "qhd",     "pxPerRem": 36, "width": 2560, "height": 1440, "aspectRatioName": "hdtv"},
-	{"name": "mac",     "pxPerRem": 36, "width": 2560, "height": 1600, "aspectRatioName": "hdtv"},
 	{"name": "uhd",     "pxPerRem": 48, "width": 3840, "height": 2160, "aspectRatioName": "hdtv", "base": true},
 	{"name": "uhd2",    "pxPerRem": 96, "width": 7680, "height": 4320, "aspectRatioName": "hdtv"}
 ]

--- a/console/screenTypes.json
+++ b/console/screenTypes.json
@@ -1,7 +1,7 @@
 [
 	{"name": "pal",     "pxPerRem": 12, "width": 1024, "height": 576,  "aspectRatioName": "hdtv"},
 	{"name": "hd",      "pxPerRem": 16, "width": 1280, "height": 720,  "aspectRatioName": "hdtv"},
-	{"name": "mac",     "pxPerRem": 36, "width": 1440, "height": 900,  "aspectRatioName": "hdtv"},
+	{"name": "mac",     "pxPerRem": 24, "width": 1680, "height": 1050, "aspectRatioName": "hdtv"},
 	{"name": "fhd",     "pxPerRem": 24, "width": 1920, "height": 1080, "aspectRatioName": "hdtv"},
 	{"name": "uw-uxga", "pxPerRem": 24, "width": 2560, "height": 1080, "aspectRatioName": "cinema"},
 	{"name": "qhd",     "pxPerRem": 36, "width": 2560, "height": 1440, "aspectRatioName": "hdtv"},

--- a/console/screenTypes.json
+++ b/console/screenTypes.json
@@ -1,0 +1,10 @@
+[
+	{"name": "pal",    "pxPerRem": 12, "width": 1024, "height": 576,  "aspectRatioName": "hdtv"},
+	{"name": "hd",      "pxPerRem": 16, "width": 1280, "height": 720,  "aspectRatioName": "hdtv"},
+	{"name": "fhd",     "pxPerRem": 24, "width": 1920, "height": 1080, "aspectRatioName": "hdtv"},
+	{"name": "uw-uxga", "pxPerRem": 24, "width": 2560, "height": 1080, "aspectRatioName": "cinema"},
+	{"name": "qhd",     "pxPerRem": 36, "width": 2560, "height": 1440, "aspectRatioName": "hdtv"},
+	{"name": "mac",     "pxPerRem": 36, "width": 2560, "height": 1600, "aspectRatioName": "hdtv"},
+	{"name": "uhd",     "pxPerRem": 48, "width": 3840, "height": 2160, "aspectRatioName": "hdtv", "base": true},
+	{"name": "uhd2",    "pxPerRem": 96, "width": 7680, "height": 4320, "aspectRatioName": "hdtv"}
+]

--- a/console/screenTypes.json
+++ b/console/screenTypes.json
@@ -1,8 +1,8 @@
 [
 	{"name": "pal",     "pxPerRem": 12, "width": 1024, "height": 576,  "aspectRatioName": "hdtv"},
 	{"name": "hd",      "pxPerRem": 16, "width": 1280, "height": 720,  "aspectRatioName": "hdtv"},
-	{"name": "mac",     "pxPerRem": 24, "width": 1680, "height": 1050, "aspectRatioName": "hdtv", "base": true},
-	{"name": "fhd",     "pxPerRem": 24, "width": 1920, "height": 1080, "aspectRatioName": "hdtv"},
+	{"name": "mac",     "pxPerRem": 24, "width": 1680, "height": 1050, "aspectRatioName": "hdtv"},
+	{"name": "fhd",     "pxPerRem": 24, "width": 1920, "height": 1080, "aspectRatioName": "hdtv", "base": true},
 	{"name": "uw-uxga", "pxPerRem": 24, "width": 2560, "height": 1080, "aspectRatioName": "cinema"},
 	{"name": "qhd",     "pxPerRem": 36, "width": 2560, "height": 1440, "aspectRatioName": "hdtv"},
 	{"name": "uhd",     "pxPerRem": 48, "width": 3840, "height": 2160, "aspectRatioName": "hdtv"},

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -17,6 +17,7 @@ import UserAvatar from '../components/UserAvatar';
 import UserSelectionPopup from '../components/UserSelectionPopup';
 import WelcomePopup from '../components/WelcomePopup';
 import ServiceLayer from '../data/ServiceLayer';
+import screenTypes from '../../screenTypes.json';
 import AppList from '../views/AppList';
 import Dashboard from '../views/Dashboard';
 import Home from '../views/Home';
@@ -30,7 +31,6 @@ import ThemeSettings from '../views/ThemeSettings';
 import Weather from '../views/WeatherPanel';
 
 import AppContextConnect from './AppContextConnect';
-import screenTypes from '../../screenTypes.json';
 
 import css from './App.module.less';
 

--- a/console/src/App/App.js
+++ b/console/src/App/App.js
@@ -30,6 +30,7 @@ import ThemeSettings from '../views/ThemeSettings';
 import Weather from '../views/WeatherPanel';
 
 import AppContextConnect from './AppContextConnect';
+import screenTypes from '../../screenTypes.json';
 
 import css from './App.module.less';
 
@@ -419,11 +420,10 @@ const AppDecorator = compose(
 		updateAppState,
 		userId
 	})),
-	AppIndex,
-	ThemeDecorator
+	AppIndex
 );
 
-const App = AppDecorator(AppBase);
+const App = AppDecorator(ThemeDecorator({ri: {screenTypes}}, AppBase));
 
 export default App;
 export {

--- a/console/src/App/App.module.less
+++ b/console/src/App/App.module.less
@@ -18,7 +18,7 @@
 		text-align: center;
 
 		.avatar {
-			margin: 1em;
+			margin: 0.5em;
 
 			.image {
 				margin: 0 auto;

--- a/console/src/components/AppIconCell/AppIconCell.module.less
+++ b/console/src/components/AppIconCell/AppIconCell.module.less
@@ -14,6 +14,14 @@
 
 // Theme-specific rules
 .applySkins({
+	:global(.silicon) {
+		.iconCell {
+			.labeledIconButton {
+				min-width: 96px;
+			}
+		}
+	}
+
 	:global(.cobalt),
 	:global(.copper) {
 		.iconCell {

--- a/console/src/components/AppIconCell/AppIconCell.module.less
+++ b/console/src/components/AppIconCell/AppIconCell.module.less
@@ -4,6 +4,7 @@
 	// styles can be put here
 	margin: 0;
 	min-width: 99px;
+
 	.applySkins({
 		.label {
 			font-size: 24px;

--- a/console/src/components/UserAvatar/UserAvatar.module.less
+++ b/console/src/components/UserAvatar/UserAvatar.module.less
@@ -14,11 +14,11 @@
 		@image-border-width: 6px;
 
 		.image {
-			width: 150px;
-			height: 150px;
+			width: 144px;
+			height: 144px;
 			background-clip: padding-box;
 			border: @image-border-width solid rgba(0, 0, 0, 0.1);
-			padding: 75px 0;
+			padding: 54px 0;
 		}
 	}
 
@@ -31,7 +31,6 @@
 
 	&.large {
 		@image-border-width: 9px;
-
 		width: 390px;
 
 		.caption {

--- a/console/src/components/UserSelectionPopup/UserSelectionPopup.module.less
+++ b/console/src/components/UserSelectionPopup/UserSelectionPopup.module.less
@@ -13,17 +13,15 @@
 			font-size: 160%;
 			padding: @agate-component-spacing;
 
+			&:global(.silicon) {
+				height: 180px;
+			}
+
 			.avatar {
 				display: inline-flex;
 				line-height: initial;
 				margin-right: @agate-component-spacing;
 				vertical-align: middle;
-
-				&:global(.silicon) {
-					.image {
-						padding: 0;
-					}
-				}
 			}
 
 			.content {

--- a/console/src/views/AppList.js
+++ b/console/src/views/AppList.js
@@ -34,28 +34,28 @@ const AppList = kind({
 	render: ({onTabChange, onTogglePopup, onToggleBasicPopup, onPopupOpen, ...rest}) => (
 		<Panel {...rest}>
 			<Column align="center center">
-				<Cell>
+				<Cell shrink>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="climate" data-tabindex={getPanelIndexOf('hvac')} onKeyUp={onTabChange} onClick={onTabChange}>Climate</AppIconCell>
 						<AppIconCell icon="compass" data-tabindex={getPanelIndexOf('map')} onKeyUp={onTabChange} onClick={onTabChange}>Navigation</AppIconCell>
 						<AppIconCell icon="phone" data-tabindex={getPanelIndexOf('phone')} onKeyUp={onTabChange} onClick={onTabChange}>Phone</AppIconCell>
 					</Row>
 				</Cell>
-				<Cell>
+				<Cell shrink>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="radio" data-tabindex={getPanelIndexOf('radio')} onKeyUp={onTabChange} onClick={onTabChange}>Radio</AppIconCell>
 						<AppIconCell icon="rearscreen" data-tabindex={getPanelIndexOf('multimedia')} onKeyUp={onTabChange} onClick={onTabChange}>Multimedia</AppIconCell>
 						<AppIconCell icon="pairing" onKeyUp={onPopupOpen} onClick={onToggleBasicPopup}>Connect</AppIconCell>
 					</Row>
 				</Cell>
-				<Cell>
+				<Cell shrink>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="dashboard" data-tabindex={getPanelIndexOf('dashboard')} onKeyUp={onTabChange} onClick={onTabChange}>Dashboard</AppIconCell>
 						<AppIconCell icon="setting" data-tabindex={getPanelIndexOf('settings')} onKeyUp={onTabChange} onClick={onTabChange}>Settings</AppIconCell>
 						<AppIconCell icon="closex" onClick={onTogglePopup}>Point of Interest</AppIconCell>
 					</Row>
 				</Cell>
-				<Cell>
+				<Cell shrink>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="weather" data-tabindex={getPanelIndexOf('weather')} onKeyUp={onTabChange} onClick={onTabChange}>Weather</AppIconCell>
 					</Row>

--- a/console/src/views/AppList.js
+++ b/console/src/views/AppList.js
@@ -34,28 +34,28 @@ const AppList = kind({
 	render: ({onTabChange, onTogglePopup, onToggleBasicPopup, onPopupOpen, ...rest}) => (
 		<Panel {...rest}>
 			<Column align="center center">
-				<Cell shrink>
+				<Cell>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="climate" data-tabindex={getPanelIndexOf('hvac')} onKeyUp={onTabChange} onClick={onTabChange}>Climate</AppIconCell>
 						<AppIconCell icon="compass" data-tabindex={getPanelIndexOf('map')} onKeyUp={onTabChange} onClick={onTabChange}>Navigation</AppIconCell>
 						<AppIconCell icon="phone" data-tabindex={getPanelIndexOf('phone')} onKeyUp={onTabChange} onClick={onTabChange}>Phone</AppIconCell>
 					</Row>
 				</Cell>
-				<Cell shrink>
+				<Cell>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="radio" data-tabindex={getPanelIndexOf('radio')} onKeyUp={onTabChange} onClick={onTabChange}>Radio</AppIconCell>
 						<AppIconCell icon="rearscreen" data-tabindex={getPanelIndexOf('multimedia')} onKeyUp={onTabChange} onClick={onTabChange}>Multimedia</AppIconCell>
 						<AppIconCell icon="pairing" onKeyUp={onPopupOpen} onClick={onToggleBasicPopup}>Connect</AppIconCell>
 					</Row>
 				</Cell>
-				<Cell shrink>
+				<Cell>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="dashboard" data-tabindex={getPanelIndexOf('dashboard')} onKeyUp={onTabChange} onClick={onTabChange}>Dashboard</AppIconCell>
 						<AppIconCell icon="setting" data-tabindex={getPanelIndexOf('settings')} onKeyUp={onTabChange} onClick={onTabChange}>Settings</AppIconCell>
 						<AppIconCell icon="closex" onClick={onTogglePopup}>Point of Interest</AppIconCell>
 					</Row>
 				</Cell>
-				<Cell shrink>
+				<Cell>
 					<Row className={css.row} align="start center">
 						<AppIconCell icon="weather" data-tabindex={getPanelIndexOf('weather')} onKeyUp={onTabChange} onClick={onTabChange}>Weather</AppIconCell>
 					</Row>

--- a/console/src/views/Settings.module.less
+++ b/console/src/views/Settings.module.less
@@ -44,6 +44,10 @@
 
 		.spacedItem {
 			margin-bottom: @settings-vertical-spacing;
+
+			.sliderButtonRow {
+				margin: 0;
+			}
 		}
 	});
 }

--- a/console/src/views/Settings.module.less
+++ b/console/src/views/Settings.module.less
@@ -46,7 +46,7 @@
 			margin-bottom: @settings-vertical-spacing;
 
 			.sliderButtonRow {
-				margin: 0;
+				margin: 6px 0 18px;
 			}
 		}
 	});

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -54,7 +54,7 @@ const FormRow = kind({
 	},
 	render: ({alignLabel, children, css, label, ...rest}) => (
 		<Row align="center" {...rest}>
-			<Cell component="label" className={css.label} align={alignLabel} size="15%">{label}</Cell>
+			<Cell component="label" className={css.label} align={alignLabel} size="10%">{label}</Cell>
 			{children}
 		</Row>
 	)
@@ -122,7 +122,7 @@ const ThemeSettingsBase = kind({
 		}
 	},
 
-	render: ({css, onChange, onSelect, prevIndex, ...rest}) => {
+	render: ({css, onChange, onSelect, prevIndex, skin, ...rest}) => {
 		delete rest.onSendSkinSettings;
 
 		return (
@@ -134,14 +134,14 @@ const ThemeSettingsBase = kind({
 							icon="arrowlargeleft"
 							labelPosition="after"
 							onClick={onSelect}
-							size={rest.skin === 'silicon' ? 'small' : 'large'}
+							size={skin === 'silicon' ? 'small' : 'large'}
 						>
 							Back
 						</LabeledIconButton>
 					</Cell>
 				</Row>
 				<Row align=" center">
-					<Cell size="70%">
+					<Cell size="80%">
 						<Column className={css.content}>
 							<Cell
 								component={Heading}
@@ -157,7 +157,7 @@ const ThemeSettingsBase = kind({
 									<HighlightColorSetting label="Highlight Color" onClick={onChange}>{swatchPalette}</HighlightColorSetting>
 								</FormRow>
 							</Cell>
-							<Cell shrink className={css.spacedItem}>
+							<Cell className={css.spacedItem}>
 								<SkinSetting label="Skin:" onClick={onChange}>
 									{skinNames}
 								</SkinSetting>

--- a/console/src/views/ThemeSettings.js
+++ b/console/src/views/ThemeSettings.js
@@ -157,7 +157,7 @@ const ThemeSettingsBase = kind({
 									<HighlightColorSetting label="Highlight Color" onClick={onChange}>{swatchPalette}</HighlightColorSetting>
 								</FormRow>
 							</Cell>
-							<Cell className={css.spacedItem}>
+							<Cell className={css.spacedItem} shrink>
 								<SkinSetting label="Skin:" onClick={onChange}>
 									{skinNames}
 								</SkinSetting>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist 

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Console app needs some adjustments for Mac resolution but also some other styling issues fixes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Adjusted the following:
- added `screentypes.json` to set Mac resolution
- layout of themeSettings page so that all skin names fit into the slider buttons
- user avatar height
- items height from user selection popup for silicon skin
- labeled icon buttons' width for silicon skin in appList view (labels were overlapping each other)  

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-13737

### Comments