### PR TITLE
WRP-19327: Updated immer dependency to the latest major version

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -39,7 +39,7 @@
 		"@enact/ui": "^4.7.1",
 		"classnames": "^2.3.2",
 		"ilib": "^14.17.0",
-		"immer": "^9.0.21",
+		"immer": "^10.0.2",
 		"mapbox-gl": "^1.13.3",
 		"prop-types": "^15.8.1",
 		"query-string": "^8.1.0",

--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -1,4 +1,4 @@
-import {produce} from "immer"
+import {produce} from 'immer';
 import PropTypes from 'prop-types';
 import {assocPath, equals, mergeDeepRight, omit, path} from 'ramda';
 import {Component, createContext, Fragment, PureComponent} from 'react';

--- a/console/src/App/AppContextProvider.js
+++ b/console/src/App/AppContextProvider.js
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import {produce} from "immer"
 import PropTypes from 'prop-types';
 import {assocPath, equals, mergeDeepRight, omit, path} from 'ramda';
 import {Component, createContext, Fragment, PureComponent} from 'react';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Updated `immer` dependency to the latest major version `^10.0.2`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We are now using `immer` dependency's latest major version `^10.0.2`.
Replace `import produce from 'immer'` with `import {produce} from 'immer'` following the migration steps:
https://github.com/immerjs/immer/releases (check  v. 10.0.0)
There were no other breaking changes affecting our code.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-19327

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla [andrei.tirla@lgepartner.com](mailto:andrei.tirla@lgepartner.com)