### PR TITLE
WRP-26105: Updated dependencies to the latest major version

### DIFF
--- a/communication-server/package.json
+++ b/communication-server/package.json
@@ -18,6 +18,6 @@
     "socket.io": "^4.7.1"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^3.0.1"
   }
 }

--- a/console/package.json
+++ b/console/package.json
@@ -50,6 +50,6 @@
 		"socket.io-client": "^4.7.1"
 	},
 	"devDependencies": {
-		"cpy-cli": "^4.2.0"
+		"cpy-cli": "^5.0.0"
 	}
 }

--- a/copilot/package.json
+++ b/copilot/package.json
@@ -41,6 +41,6 @@
 		"react-dom": "^18.2.0"
 	},
 	"devDependencies": {
-		"cpy-cli": "^4.2.0"
+		"cpy-cli": "^5.0.0"
 	}
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Updated `cpy-cli` and `nodemon` dependencies to latest major version.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Agate-apps now uses the latest major version for `cpy-cli` and `nodemon`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
`mapbox-gl` has a major update ^2.15.0 which is a paid version now, so we should stay at ^1.13.1 for free version.
There were no breaking changes affecting this repo.

### Links
[//]: # (Related issues, references)
WRP-26105
https://github.com/sindresorhus/cpy-cli/releases
https://github.com/remy/nodemon/releases

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com